### PR TITLE
Fractional split duplication bug

### DIFF
--- a/ambrosia/spark_tools/split_tools.py
+++ b/ambrosia/spark_tools/split_tools.py
@@ -29,7 +29,7 @@ EMPTY_VALUE: int = 0
 
 def unite_spark_tables(*dataframes: types.SparkDataFrame) -> types.SparkDataFrame:
     """
-    Union all spark dataframes
+    Union all spark dataframes.
     """
     amount_of_dataframes = len(dataframes)
     if not amount_of_dataframes:
@@ -47,7 +47,8 @@ def add_hash_column(
     salt: Optional[str] = None,
 ) -> types.SparkDataFrame:
     """
-    Returns new dataframe with column hashing id_column
+    Returns new dataframe with column hashing id_column.
+
     Parameters
     ----------
     hash_function: str, default ``sha_256``
@@ -78,7 +79,7 @@ def get_hash_split(
     salt: Optional[str] = None,
 ) -> types.SparkDataFrame:
     """
-    Hash split
+    Hash split.
     """
     hashed_dataframe = add_hash_column(dataframe, id_column, hash_function, salt)
     hashed_dataframe = hashed_dataframe.orderBy(HASH_COLUMN_NAME).limit(groups_number * groups_size)
@@ -104,7 +105,7 @@ def add_to_required_size(
     labels: Iterable[str],
 ) -> types.SparkDataFrame:
     """
-    Add elements for groups to required size
+    Add elements for groups to required size.
     """
     not_used_ids: types.SparkDataFrame = dataframe.join(used_dataframe, on=id_column, how="leftanti")
     required_sizes: List[int] = [groups_size - size_ for size_ in current_sizes]
@@ -145,12 +146,15 @@ def get_split(
     labels: Optional[Iterable[str]] = None,
 ) -> types.SparkDataFrame:
     """
-    Get split
+    Get split.
     """
     total_size: int = dataframe.count()
 
     if groups_number * groups_size > total_size:
         raise ValueError("Total sample size is more, than shape of table")
+
+    if total_size > dataframe.dropDuplicates([id_column]).count():
+        raise ValueError(f"Id column {id_column} contains duplicates, ids must be unique for split")
 
     if labels is None:
         labels = split_tools.make_labels_for_groups(groups_number)

--- a/ambrosia/splitter/handlers.py
+++ b/ambrosia/splitter/handlers.py
@@ -53,7 +53,7 @@ def add_data_pandas(dataframe: pd.DataFrame, splitted_dataframe: pd.DataFrame, g
     customized_table : pd.DataFrame
         Table, where rest of table is added.
     """
-    additional_table: pd.DataFrame = dataframe.iloc[dataframe.index.delete(splitted_dataframe.index)].copy()
+    additional_table: pd.DataFrame = dataframe.loc[dataframe.index.delete(splitted_dataframe.index)].copy()
     additional_table[GROUPS_COLUMN] = group_label
     customized_table = pd.concat([splitted_dataframe, additional_table])
     return customized_table
@@ -157,6 +157,15 @@ def split_data_handler(**kwargs) -> types.SplitterResult:
     """
     Call split function according to table type.
     """
+    if isinstance(kwargs[DATA], pd.DataFrame):
+        return split_pandas.get_split(**kwargs)
+    elif isinstance(kwargs[DATA], types.SparkDataFrame):
+        return split_spark.get_split(**kwargs)
+    else:
+        raise TypeError(f'Type of table must be one of {", ".join(AVAILABLE)}')
+
+
+def duplicates_handler(**kwargs):
     if isinstance(kwargs[DATA], pd.DataFrame):
         return split_pandas.get_split(**kwargs)
     elif isinstance(kwargs[DATA], types.SparkDataFrame):

--- a/ambrosia/splitter/handlers.py
+++ b/ambrosia/splitter/handlers.py
@@ -163,12 +163,3 @@ def split_data_handler(**kwargs) -> types.SplitterResult:
         return split_spark.get_split(**kwargs)
     else:
         raise TypeError(f'Type of table must be one of {", ".join(AVAILABLE)}')
-
-
-def duplicates_handler(**kwargs):
-    if isinstance(kwargs[DATA], pd.DataFrame):
-        return split_pandas.get_split(**kwargs)
-    elif isinstance(kwargs[DATA], types.SparkDataFrame):
-        return split_spark.get_split(**kwargs)
-    else:
-        raise TypeError(f'Type of table must be one of {", ".join(AVAILABLE)}')

--- a/ambrosia/tools/split_tools.py
+++ b/ambrosia/tools/split_tools.py
@@ -40,7 +40,7 @@ def check_ids_duplicates(
     """
     Check if column with objects ids contains duplicates.
     """
-    indices: np.ndarray = dataframe.id_column.values if id_column is not None else dataframe.index
+    indices: np.ndarray = dataframe[id_column].values if id_column is not None else dataframe.index
     if len(indices) > len(set(indices)):
         raise ValueError(f"Id column {id_column} contains duplicates, ids must be unique for split")
 

--- a/ambrosia/tools/split_tools.py
+++ b/ambrosia/tools/split_tools.py
@@ -33,9 +33,22 @@ GROUPS_COLUMNS: str = "group"
 AVAILLABLE_SPLIT_METHODS = ["simple", "hash", "metric", "dim_decrease"]
 
 
+def check_ids_duplicates(
+    dataframe: pd.DataFrame,
+    id_column: Optional[types.ColumnNameType] = None,
+) -> None:
+    """
+    Check if column with objects ids contains duplicates.
+    """
+    indices: np.ndarray = dataframe.id_column.values if id_column is not None else dataframe.index
+    if len(indices) > len(set(indices)):
+        raise ValueError(f"Id column {id_column} contains duplicates, ids must be unique for split")
+
+
 def get_integer_salt(salt: Optional[str]) -> int:
     """
-    Returns integer for random state numpy
+    Returns integer for random state numpy.
+
     Parameters
     ----------
     salt: Optional str
@@ -384,6 +397,7 @@ def get_split(
     groups : pd.DataFrame
         DataFrame with "group" column with group labels.
     """
+    check_ids_duplicates(dataframe, id_column)
     if stratifier is None:
         stratifier = strat_pkg.Stratification()
         stratifier.fit(dataframe, strat_columns)


### PR DESCRIPTION
This bug was described at #10 

Now `Splitter` is checking for duplicates in `id_column` at each run. If there are any of these, an error will be raised.

It seems logically correct that in almost all groups splitting problems, we want to have unique id for each object(row).
In special cases, one can create an additional column with a unique id, and it will be much simplier rather than handling issues with hashing, index search, etc inside `Splitter` methods.
