### PR TITLE
Add multiple testing corrections to Tester (Holm, Sidak, FDR, Hommel, ...)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,19 +6,26 @@ Version 0.5.2 (unreleased)
 
 **New Features:**
 
-* Additional multiple hypothesis testing corrections in ``Tester``. The
-  ``correction_method`` parameter now accepts ``"sidak"``, ``"holm"``,
-  ``"holm-sidak"``, ``"fdr_bh"`` (Benjamini-Hochberg), ``"fdr_by"``
-  (Benjamini-Yekutieli), ``"hommel"`` and ``"simes-hochberg"`` in addition to
-  the default ``"bonferroni"`` (pass ``None`` to disable). The Benjamini-Hochberg
-  and Benjamini-Yekutieli procedures control the false discovery rate, while the
-  step-wise family-wise procedures (Holm, Holm-Sidak, Hommel, Hochberg) are more
-  powerful than Bonferroni - Holm uniformly so, with Hommel and Hochberg more
-  powerful still under independence or positive dependence. For ``"bonferroni"``
-  and ``"sidak"`` confidence
-  intervals are widened accordingly; the step-wise methods adjust only the
-  p-values and leave intervals at the nominal level. Common aliases such as
-  ``"benjamini-hochberg"`` are also accepted.
+* The ``Tester`` now offers several ways to correct p-values when an experiment
+  evaluates many metrics or many groups at once, not just Bonferroni. Running a
+  lot of comparisons together inflates the chance of a false positive, and a
+  correction keeps that chance under control. The ``correction_method`` argument
+  now accepts:
+
+  * ``"bonferroni"`` (the default, unchanged), ``"holm"``, ``"holm-sidak"``,
+    ``"sidak"``, ``"hommel"`` and ``"simes-hochberg"`` - methods that limit the
+    probability of making *any* false positive. ``"holm"`` and the others are
+    less conservative than Bonferroni, so you keep more statistical power.
+  * ``"fdr_bh"`` (Benjamini-Hochberg) and ``"fdr_by"`` (Benjamini-Yekutieli) -
+    methods that control the false discovery rate, i.e. the expected share of
+    false positives among the metrics you call significant. A popular choice
+    when a dashboard tracks many metrics.
+
+  Existing code keeps working unchanged: Bonferroni stays the default and
+  ``correction_method=None`` turns correction off. Friendly aliases such as
+  ``"benjamini-hochberg"`` are also accepted. For ``"bonferroni"`` and
+  ``"sidak"`` the confidence intervals are widened to match; the other methods
+  adjust the p-values only.
 
 **Internal:**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,30 @@
 Release Notes
 =============
 
+Version 0.5.2 (unreleased)
+---------------------------
+
+**New Features:**
+
+* Additional multiple hypothesis testing corrections in ``Tester``. The
+  ``correction_method`` parameter now accepts ``"sidak"``, ``"holm"``,
+  ``"holm-sidak"``, ``"fdr_bh"`` (Benjamini-Hochberg), ``"fdr_by"``
+  (Benjamini-Yekutieli), ``"hommel"`` and ``"simes-hochberg"`` in addition to
+  the default ``"bonferroni"`` (pass ``None`` to disable). The Benjamini-Hochberg
+  and Benjamini-Yekutieli procedures control the false discovery rate, while the
+  step-wise family-wise procedures (Holm, Holm-Sidak, Hommel, Hochberg) are more
+  powerful than Bonferroni - Holm uniformly so, with Hommel and Hochberg more
+  powerful still under independence or positive dependence. For ``"bonferroni"``
+  and ``"sidak"`` confidence
+  intervals are widened accordingly; the step-wise methods adjust only the
+  p-values and leave intervals at the nominal level. Common aliases such as
+  ``"benjamini-hochberg"`` are also accepted.
+
+**Internal:**
+
+* Added ``ambrosia/tools/multitest.py`` with native p-value adjustment
+  procedures, cross-validated against ``statsmodels`` and R's ``p.adjust``.
+
 Version 0.5.1 (26.03.2026)
 ---------------------------
 

--- a/ambrosia/tester/tester.py
+++ b/ambrosia/tester/tester.py
@@ -36,6 +36,7 @@ import numpy as np
 import pandas as pd
 
 import ambrosia.tools.empirical_tools as empirical_pkg
+import ambrosia.tools.multitest as multitest_pkg
 import ambrosia.tools.pvalue_tools as pvalue_pkg
 import ambrosia.tools.stat_criteria as criteria_pkg
 from ambrosia import types
@@ -52,7 +53,7 @@ AVAILABLE_AB_CRITERIA: Dict[str, ABStatCriterion] = {
     "mw": criteria_pkg.MannWhitneyCriterion,
     "wilcoxon": criteria_pkg.WilcoxonCriterion,
 }
-AVAILABLE_MULTITEST_CORRECTIONS: List[str] = ["bonferroni"]
+AVAILABLE_MULTITEST_CORRECTIONS: List[str] = multitest_pkg.available_methods()
 
 
 class Tester(ABToolAbstract):
@@ -416,28 +417,33 @@ class Tester(ABToolAbstract):
         return result
 
     @staticmethod
-    def __apply_first_stage_multitest_correction(
-        alphas: types.StatErrorType, hypothesis_num: int, method: str = "bonferroni"
-    ) -> types.StatErrorType:
+    def __apply_multitest_correction(
+        result: types.TesterResult,
+        metrics: List[types.MetricNameType],
+        method: str,
+        nominal_alpha: np.ndarray,
+    ) -> None:
         """
-        Apply first stage of multitest correction for first type errors.
-        """
-        alphas = alphas.copy()
-        if method == "bonferroni":
-            alphas /= hypothesis_num
-        return alphas
+        Adjust p-values across the whole family of tested hypotheses in place.
 
-    @staticmethod
-    def __apply_second_stage_multitest_correction(
-        result: types.TesterResult, hypothesis_num: int, method: str = "bonferroni"
-    ):
+        The family consists of one p-value per (group pair, metric) combination.
+        Adjusting this vector directly - rather than the flattened result table,
+        which repeats each p-value once per first type error level - keeps the
+        rank-based procedures (Holm, Benjamini-Hochberg, Hommel, ...) correct.
+        The reported ``first_type_error`` is restored to the nominal level, while
+        any confidence-interval widening already performed for the
+        constant-scaling methods (Bonferroni, Sidak) is left untouched.
         """
-        Apply second stage of multitest correction.
-        """
-        if method == "bonferroni":
-            result["pvalue"] = (result["pvalue"].values * hypothesis_num).clip(max=1)
-            result["first_type_error"] *= hypothesis_num
-        return result
+        coordinates: List = []
+        pvalues: List[float] = []
+        for test_name, subresult in result.items():
+            for metric in metrics:
+                coordinates.append((test_name, metric))
+                pvalues.append(float(subresult[metric]["pvalue"]))
+        adjusted: np.ndarray = multitest_pkg.adjust_pvalues(np.asarray(pvalues), method)
+        for (test_name, metric), pvalue in zip(coordinates, adjusted):
+            result[test_name][metric]["pvalue"] = float(pvalue)
+            result[test_name][metric]["first_type_error"] = nominal_alpha
 
     @staticmethod
     def as_table(dict_result: types.TesterResult) -> pd.DataFrame:
@@ -524,10 +530,17 @@ class Tester(ABToolAbstract):
             Statistical criterion for hypotheses testing.
             If ``method`` is ``"theory"`` and no criterion provided,
             ttest for independent samples will be used.
-        correction_method : Union[str, None], default: ``bonferroni``
-            Method for pvalues and confidence intervals multitest correction.
-            Total number of hypothesis is equal to the number of
-            variants combinations * number of metrics passed.
+        correction_method : Union[str, None], default: ``"bonferroni"``
+            Method for multiple hypothesis testing correction of p-values.
+            Supported values: ``"bonferroni"``, ``"sidak"``, ``"holm"``,
+            ``"holm-sidak"``, ``"fdr_bh"`` (Benjamini-Hochberg),
+            ``"fdr_by"`` (Benjamini-Yekutieli), ``"hommel"``,
+            ``"simes-hochberg"``; pass ``None`` to disable correction.
+            The family size equals the number of group-pair combinations
+            times the number of metrics. For ``"bonferroni"`` and ``"sidak"``
+            confidence intervals are widened accordingly; the other, step-wise
+            methods adjust only the p-values and leave intervals at the nominal
+            level.
         as_table : bool, default: ``True``
             Return the test results as a pandas dataframe.
             If ``False``, a list of dicts with results will be returned.
@@ -583,13 +596,15 @@ class Tester(ABToolAbstract):
         hypothesis_num: int = len(list(itertools.combinations(chosen_args["experiment_results"], 2))) * len(
             chosen_args["metrics"]
         )
-        if correction_method is not None and hypothesis_num > 1:
-            if correction_method in AVAILABLE_MULTITEST_CORRECTIONS:
-                chosen_args["alpha"] = Tester.__apply_first_stage_multitest_correction(
-                    chosen_args["alpha"], hypothesis_num, correction_method
-                )
-            else:
-                raise ValueError(f"Choose correction method from {AVAILABLE_MULTITEST_CORRECTIONS}")
+        apply_correction: bool = correction_method is not None and hypothesis_num > 1
+        nominal_alpha: np.ndarray = np.array(chosen_args["alpha"])
+        if apply_correction:
+            correction_method = multitest_pkg.validate_method(correction_method)
+            # Stage 1: widen confidence intervals for constant-scaling methods
+            # (Bonferroni, Sidak); the step-wise methods keep the nominal level.
+            chosen_args["alpha"] = multitest_pkg.alpha_for_confidence_interval(
+                nominal_alpha, correction_method, hypothesis_num
+            )
 
         result: types.TesterResult = {}
         # Variating over all pairs of groups - comb(n, 2)
@@ -603,9 +618,11 @@ class Tester(ABToolAbstract):
             subresult["group_b_label"] = group_b_label
             result[test_name] = subresult
 
+        # Stage 2: adjust the family of p-values and restore the reported alpha.
+        if apply_correction:
+            Tester.__apply_multitest_correction(result, chosen_args["metrics"], correction_method, nominal_alpha)
+
         result = Tester.as_table(result)
-        if correction_method is not None and hypothesis_num > 1:
-            result = Tester.__apply_second_stage_multitest_correction(result, hypothesis_num, correction_method)
         if not as_table:
             result = result.to_dict(orient="records")
         return result
@@ -666,10 +683,17 @@ def test(
         Statistical criterion for hypotheses testing.
         If ``method`` is ``"theory"`` and no criterion provided,
         ttest for independent samples will be used.
-    correction_method : Union[str, None], default: ``bonferroni``
-        Method for pvalues and confidence intervals multitest correction.
-        Total number of hypothesis is equal to the number of
-        variants combinations * number of metrics passed.
+    correction_method : Union[str, None], default: ``"bonferroni"``
+        Method for multiple hypothesis testing correction of p-values.
+        Supported values: ``"bonferroni"``, ``"sidak"``, ``"holm"``,
+        ``"holm-sidak"``, ``"fdr_bh"`` (Benjamini-Hochberg),
+        ``"fdr_by"`` (Benjamini-Yekutieli), ``"hommel"``,
+        ``"simes-hochberg"``; pass ``None`` to disable correction.
+        The family size equals the number of group-pair combinations
+        times the number of metrics. For ``"bonferroni"`` and ``"sidak"``
+        confidence intervals are widened accordingly; the other, step-wise
+        methods adjust only the p-values and leave intervals at the nominal
+        level.
     as_table : bool, default: ``True``
         Return the test results as a pandas dataframe.
         If ``False``, a list of dicts with results will be returned.

--- a/ambrosia/tools/configs.py
+++ b/ambrosia/tools/configs.py
@@ -52,3 +52,18 @@ class Alternatives(AmbrosiaEnum):
 class Effects(AmbrosiaEnum):
     abs: str = "absolute"
     rel: str = "relative"
+
+
+class MultipleTestingCorrection(AmbrosiaEnum):
+    """
+    Supported multiple hypothesis testing correction methods.
+    """
+
+    bonferroni: str = "bonferroni"
+    sidak: str = "sidak"
+    holm: str = "holm"
+    holm_sidak: str = "holm-sidak"
+    fdr_bh: str = "fdr_bh"
+    fdr_by: str = "fdr_by"
+    hommel: str = "hommel"
+    simes_hochberg: str = "simes-hochberg"

--- a/ambrosia/tools/multitest.py
+++ b/ambrosia/tools/multitest.py
@@ -1,0 +1,267 @@
+#  Copyright 2022 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Multiple hypothesis testing corrections.
+
+This module provides p-value adjustment procedures and confidence-interval
+significance-level rescaling used by the ``Tester`` to control error rates when
+several hypotheses (metric x group-pair combinations) are evaluated together.
+
+Two families of methods are supported:
+
+* **alpha-scaling** methods (``bonferroni``, ``sidak``) apply a constant
+  per-test transformation. Both the reported p-values and the confidence
+  intervals can be adjusted consistently, so for these methods the interval is
+  rebuilt at a rescaled significance level.
+* **step-wise / rank-based** methods (``holm``, ``holm-sidak``, ``fdr_bh``,
+  ``fdr_by``, ``hommel``, ``simes-hochberg``) adjust p-values using the whole
+  ordered vector of p-values. No simple per-hypothesis multiplicity-adjusted
+  confidence interval exists for them, so intervals are left at the nominal
+  level and only the p-values are corrected.
+
+The adjusted p-values match ``statsmodels.stats.multitest.multipletests`` and
+R's ``stats::p.adjust`` for the corresponding method names.
+"""
+from typing import Dict, List
+
+import numpy as np
+
+from ambrosia.tools.configs import MultipleTestingCorrection
+
+# Canonical method names.
+BONFERRONI: str = "bonferroni"
+SIDAK: str = "sidak"
+HOLM: str = "holm"
+HOLM_SIDAK: str = "holm-sidak"
+FDR_BH: str = "fdr_bh"
+FDR_BY: str = "fdr_by"
+HOMMEL: str = "hommel"
+SIMES_HOCHBERG: str = "simes-hochberg"
+
+# Methods whose multiplicity adjustment is a constant per-test scaling and can
+# therefore also be reflected in confidence intervals via a rescaled alpha.
+_CI_CORRECTABLE = frozenset({BONFERRONI, SIDAK})
+
+# User-friendly aliases mapped to canonical method names.
+_ALIASES: Dict[str, str] = {
+    "benjamini-hochberg": FDR_BH,
+    "benjamini_hochberg": FDR_BH,
+    "bh": FDR_BH,
+    "benjamini-yekutieli": FDR_BY,
+    "benjamini_yekutieli": FDR_BY,
+    "by": FDR_BY,
+    "hochberg": SIMES_HOCHBERG,
+}
+
+
+def available_methods() -> List[str]:
+    """
+    Return the list of canonical correction method names.
+    """
+    return MultipleTestingCorrection.get_all_enum_values()
+
+
+def normalize_method(method: str) -> str:
+    """
+    Map a user-provided method name (possibly an alias) to its canonical form.
+
+    Unknown names are returned lower-cased and unchanged so that a single,
+    consistent validation error can be raised downstream.
+
+    Parameters
+    ----------
+    method : str
+        Correction method name or alias.
+
+    Returns
+    -------
+    str
+        Canonical method name when recognised, otherwise the normalised input.
+    """
+    if not isinstance(method, str):
+        return method
+    key: str = method.strip().lower()
+    return _ALIASES.get(key, key)
+
+
+def validate_method(method: str) -> str:
+    """
+    Normalise and validate a correction method name.
+
+    Parameters
+    ----------
+    method : str
+        Correction method name or alias.
+
+    Returns
+    -------
+    str
+        Canonical method name.
+
+    Raises
+    ------
+    ValueError
+        If the (normalised) method is not supported.
+    """
+    canonical: str = normalize_method(method)
+    MultipleTestingCorrection.raise_if_value_incorrect_enum(canonical)
+    return canonical
+
+
+def is_ci_correctable(method: str) -> bool:
+    """
+    Whether confidence intervals can be multiplicity-adjusted for ``method``.
+    """
+    return normalize_method(method) in _CI_CORRECTABLE
+
+
+def alpha_for_confidence_interval(alpha: np.ndarray, method: str, n_hypotheses: int) -> np.ndarray:
+    """
+    Per-test significance level to use when building confidence intervals.
+
+    For constant per-test ("alpha-scaling") methods the level is rescaled so the
+    interval is consistent with the adjusted decision rule. For all other methods
+    the nominal level is returned unchanged.
+
+    Parameters
+    ----------
+    alpha : np.ndarray
+        Nominal first type error level(s).
+    method : str
+        Correction method name (canonical or alias).
+    n_hypotheses : int
+        Number of simultaneously tested hypotheses (family size).
+
+    Returns
+    -------
+    np.ndarray
+        Significance level(s) for confidence-interval construction.
+    """
+    canonical: str = normalize_method(method)
+    alpha = np.asarray(alpha, dtype=float)
+    if canonical == BONFERRONI:
+        return np.asarray(alpha / n_hypotheses)
+    if canonical == SIDAK:
+        return np.asarray(1.0 - np.power(1.0 - alpha, 1.0 / n_hypotheses))
+    return alpha
+
+
+def adjust_pvalues(pvalues, method: str) -> np.ndarray:
+    """
+    Adjust a family of p-values for multiple testing.
+
+    The family size equals the full length of ``pvalues``. ``NaN`` entries are
+    excluded from ranking but still counted towards the family size (they stand
+    for family members whose test could not be computed) and are returned in
+    place as ``NaN``, matching R's ``p.adjust``. All other values must lie in
+    ``[0, 1]``.
+
+    Parameters
+    ----------
+    pvalues : array-like
+        Raw p-values, one per hypothesis.
+    method : str
+        Correction method name (canonical or alias).
+
+    Returns
+    -------
+    np.ndarray
+        Adjusted p-values, clipped to ``[0, 1]``, in the original order.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not supported, ``pvalues`` is not one-dimensional, or
+        any non-``NaN`` p-value lies outside ``[0, 1]``.
+    """
+    canonical: str = validate_method(method)
+    pvalues = np.asarray(pvalues, dtype=float)
+    if pvalues.ndim != 1:
+        raise ValueError("pvalues must be a one-dimensional array")
+    # NaN entries yield False in both comparisons and are tolerated here.
+    if np.any((pvalues < 0.0) | (pvalues > 1.0)):
+        raise ValueError("p-values must lie in [0, 1]")
+    adjusted: np.ndarray = np.full(pvalues.shape, np.nan, dtype=float)
+    valid: np.ndarray = ~np.isnan(pvalues)
+    if valid.any():
+        adjusted[valid] = _adjust_valid(pvalues[valid], canonical, pvalues.size)
+    return adjusted
+
+
+def _adjust_valid(pvalues: np.ndarray, method: str, n: int) -> np.ndarray:
+    """
+    Apply a correction to the finite (non-NaN) members of a family of size ``n``.
+
+    ``pvalues`` holds the ``k <= n`` present (non-NaN) p-values; the remaining
+    ``n - k`` members were not computed but still count towards the family size.
+    """
+    k: int = len(pvalues)
+    if k == 0:
+        return pvalues.copy()
+    if method == BONFERRONI:
+        return np.minimum(pvalues * n, 1.0)
+    if method == SIDAK:
+        # Sidak: 1 - (1 - p)^n, computed directly. The result matches statsmodels
+        # (which uses the equivalent expm1/log1p form) to floating-point precision
+        # while avoiding its divide-by-zero warning at p = 1.
+        return np.minimum(1.0 - np.power(1.0 - pvalues, n), 1.0)
+
+    # Rank-based procedures operate on the ascending-sorted p-value vector; the
+    # ranks run over the k present values while the family size stays n.
+    order: np.ndarray = np.argsort(pvalues, kind="mergesort")
+    inverse: np.ndarray = np.empty(k, dtype=int)
+    inverse[order] = np.arange(k)
+    p_sorted: np.ndarray = pvalues[order]
+    ranks: np.ndarray = np.arange(1, k + 1)  # 1-based ascending ranks
+
+    if method == HOLM:
+        adjusted = np.maximum.accumulate((n - ranks + 1) * p_sorted)
+    elif method == HOLM_SIDAK:
+        adjusted = np.maximum.accumulate(1.0 - np.power(1.0 - p_sorted, n - ranks + 1))
+    elif method == SIMES_HOCHBERG:
+        adjusted = np.minimum.accumulate((((n - ranks + 1) * p_sorted)[::-1]))[::-1]
+    elif method == FDR_BH:
+        adjusted = np.minimum.accumulate(((n / ranks) * p_sorted)[::-1])[::-1]
+    elif method == FDR_BY:
+        c_n: float = float(np.sum(1.0 / np.arange(1, n + 1)))
+        adjusted = np.minimum.accumulate(((c_n * n / ranks) * p_sorted)[::-1])[::-1]
+    elif method == HOMMEL:
+        adjusted = _hommel_sorted(p_sorted, n)
+    else:  # pragma: no cover - guarded by validate_method
+        raise ValueError(f"Unsupported correction method: {method}")
+
+    adjusted = np.minimum(adjusted, 1.0)
+    return adjusted[inverse]
+
+
+def _hommel_sorted(p_sorted: np.ndarray, n: int) -> np.ndarray:
+    """
+    Hommel (1988) adjusted p-values for an ascending-sorted p-value vector.
+
+    Implements the closed form reproduced in Wright (1992); matches the
+    ``hommel`` procedure of ``statsmodels`` and R's ``p.adjust``. When the family
+    size ``n`` exceeds the number of present p-values (some members are NaN), the
+    missing members are padded with the neutral value ``1.0`` (as in R) and only
+    the present positions are returned.
+    """
+    k: int = len(p_sorted)
+    full: np.ndarray = p_sorted if n == k else np.concatenate([p_sorted, np.ones(n - k)])
+    adjusted: np.ndarray = full.copy()
+    for size in range(n, 1, -1):
+        index = np.arange(1, size + 1)
+        cim = np.min(size * full[n - size :] / index)
+        adjusted[n - size :] = np.maximum(adjusted[n - size :], cim)
+        adjusted[: n - size] = np.maximum(adjusted[: n - size], np.minimum(size * full[: n - size], cim))
+    return adjusted[:k]

--- a/docs/source/ambrosia_elements/tester.rst
+++ b/docs/source/ambrosia_elements/tester.rst
@@ -8,8 +8,15 @@ and calculating the experimental uplift value with corresponding confidence inte
 .. admonition:: Multiple testing correction
    :class: caution
 
-   Currently, if multiple hypothesis(number of variants combinations * number of metrics passed) are tested, 
-   these groups are compared in pairs and Bonferroni correction is applied to all p-values and confidence intervals.
+   When several hypotheses (number of variant combinations * number of metrics passed) are tested,
+   the groups are compared in pairs and the p-values are adjusted for multiplicity. The
+   ``correction_method`` parameter selects the procedure: ``"bonferroni"`` (default), ``"sidak"``,
+   ``"holm"``, ``"holm-sidak"``, ``"fdr_bh"`` (Benjamini-Hochberg), ``"fdr_by"`` (Benjamini-Yekutieli),
+   ``"hommel"`` or ``"simes-hochberg"`` (pass ``None`` to disable). The Benjamini-Hochberg and
+   Benjamini-Yekutieli procedures control the false discovery rate; the others control the
+   family-wise error rate. For ``"bonferroni"`` and ``"sidak"`` the confidence intervals are widened
+   accordingly; the step-wise methods adjust only the p-values and leave the intervals at the nominal level.
+   Hypotheses whose p-value cannot be computed still count toward the family size.
 
 
 .. currentmodule:: ambrosia.tester

--- a/docs/source/nb_pandas_examples.rst
+++ b/docs/source/nb_pandas_examples.rst
@@ -13,4 +13,4 @@ Pandas Data Examples
     /pandas_examples/06_pandas_tester
     /pandas_examples/10_synthetic_experiment_full_pipeline_short
     /pandas_examples/11_cuped_example
-    
+    /pandas_examples/13_multiple_testing_corrections

--- a/docs/source/pandas_examples/13_multiple_testing_corrections.nblink
+++ b/docs/source/pandas_examples/13_multiple_testing_corrections.nblink
@@ -1,0 +1,3 @@
+{
+  "path": "../../../examples/13_multiple_testing_corrections.ipynb"
+}

--- a/examples/13_multiple_testing_corrections.ipynb
+++ b/examples/13_multiple_testing_corrections.ipynb
@@ -1,0 +1,705 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd8ffebc",
+   "metadata": {},
+   "source": [
+    "# Multiple testing corrections in Ambrosia's `Tester`\n",
+    "\n",
+    "When an experiment is evaluated on **several metrics** (or **several groups**) at once, the\n",
+    "p-values must be corrected for multiple comparisons. Since version **0.5.2**, `Tester`\n",
+    "supports eight correction methods. This notebook shows the problem and how to use each one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "093ed30c",
+   "metadata": {},
+   "source": [
+    "## 1. The multiple-comparisons problem\n",
+    "\n",
+    "A single test at the 5% level has a 5% chance of a false positive. Test many metrics and the\n",
+    "chance that **at least one** looks \"significant\" by pure luck grows fast. A multiple-testing\n",
+    "correction keeps that chance under control.\n",
+    "\n",
+    "We simulate an A/B test with six metrics: **five have no real effect** (`metric_1`..`metric_5`)\n",
+    "and **one has a real positive effect** (`metric_6`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4440876d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>group</th>\n",
+       "      <th>metric_1</th>\n",
+       "      <th>metric_2</th>\n",
+       "      <th>metric_3</th>\n",
+       "      <th>metric_4</th>\n",
+       "      <th>metric_5</th>\n",
+       "      <th>metric_6</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A</td>\n",
+       "      <td>-1.738266</td>\n",
+       "      <td>-0.006715</td>\n",
+       "      <td>-0.886940</td>\n",
+       "      <td>1.199254</td>\n",
+       "      <td>-1.841961</td>\n",
+       "      <td>-0.164049</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>A</td>\n",
+       "      <td>-1.336643</td>\n",
+       "      <td>-0.244478</td>\n",
+       "      <td>0.374934</td>\n",
+       "      <td>1.521730</td>\n",
+       "      <td>-0.789614</td>\n",
+       "      <td>-0.582462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>A</td>\n",
+       "      <td>-1.361107</td>\n",
+       "      <td>-0.471546</td>\n",
+       "      <td>-0.497588</td>\n",
+       "      <td>0.121381</td>\n",
+       "      <td>0.035406</td>\n",
+       "      <td>-1.076962</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>A</td>\n",
+       "      <td>-0.351617</td>\n",
+       "      <td>0.692823</td>\n",
+       "      <td>0.434765</td>\n",
+       "      <td>-0.011001</td>\n",
+       "      <td>-2.566139</td>\n",
+       "      <td>0.218516</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>A</td>\n",
+       "      <td>-2.312582</td>\n",
+       "      <td>-0.573991</td>\n",
+       "      <td>1.012139</td>\n",
+       "      <td>0.385061</td>\n",
+       "      <td>0.266645</td>\n",
+       "      <td>-0.536790</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  group  metric_1  metric_2  metric_3  metric_4  metric_5  metric_6\n",
+       "0     A -1.738266 -0.006715 -0.886940  1.199254 -1.841961 -0.164049\n",
+       "1     A -1.336643 -0.244478  0.374934  1.521730 -0.789614 -0.582462\n",
+       "2     A -1.361107 -0.471546 -0.497588  0.121381  0.035406 -1.076962\n",
+       "3     A -0.351617  0.692823  0.434765 -0.011001 -2.566139  0.218516\n",
+       "4     A -2.312582 -0.573991  1.012139  0.385061  0.266645 -0.536790"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from ambrosia.tester import Tester\n",
+    "\n",
+    "N = 2000  # users per group\n",
+    "rng = np.random.default_rng(8)\n",
+    "\n",
+    "data = {\"group\": [\"A\"] * N + [\"B\"] * N}\n",
+    "for i in range(1, 6):  # metric_1..metric_5: no effect (A and B from the same distribution)\n",
+    "    data[f\"metric_{i}\"] = np.r_[rng.normal(0.0, 1.0, N), rng.normal(0.0, 1.0, N)]\n",
+    "data[\"metric_6\"] = np.r_[rng.normal(0.0, 1.0, N), rng.normal(0.15, 1.0, N)]  # real effect in B\n",
+    "\n",
+    "df = pd.DataFrame(data)\n",
+    "metrics = [f\"metric_{i}\" for i in range(1, 7)]\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "187cb7ab",
+   "metadata": {},
+   "source": [
+    "## 2. Without any correction\n",
+    "\n",
+    "Run the `Tester` with `correction_method=None`. Watch the null metrics: by chance one slips\n",
+    "below the 0.05 threshold - a **false positive**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "21bded67",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>metric name</th>\n",
+       "      <th>pvalue</th>\n",
+       "      <th>significant @ 0.05</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>metric_1</td>\n",
+       "      <td>0.1387</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>metric_2</td>\n",
+       "      <td>0.4573</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>metric_3</td>\n",
+       "      <td>0.8861</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>metric_4</td>\n",
+       "      <td>0.0320</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>metric_5</td>\n",
+       "      <td>0.6910</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>metric_6</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  metric name  pvalue  significant @ 0.05\n",
+       "0    metric_1  0.1387               False\n",
+       "1    metric_2  0.4573               False\n",
+       "2    metric_3  0.8861               False\n",
+       "3    metric_4  0.0320                True\n",
+       "4    metric_5  0.6910               False\n",
+       "5    metric_6  0.0000                True"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tester = Tester(dataframe=df, column_groups=\"group\", metrics=metrics)\n",
+    "\n",
+    "raw = tester.run(\"absolute\", method=\"theory\", correction_method=None, as_table=True)\n",
+    "raw_view = raw[[\"metric name\", \"pvalue\"]].copy()\n",
+    "raw_view[\"significant @ 0.05\"] = raw_view[\"pvalue\"] < 0.05\n",
+    "raw_view.round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8459b271",
+   "metadata": {},
+   "source": [
+    "Here `metric_4` is flagged as significant even though it has no real effect, while `metric_6`\n",
+    "(the true effect) is significant too. With five null metrics there was a ~23% chance of at\n",
+    "least one such false positive."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8608b33",
+   "metadata": {},
+   "source": [
+    "## 3. Turning on a correction\n",
+    "\n",
+    "Pass a method name to `correction_method`. `\"bonferroni\"` is the default, so existing code is\n",
+    "unaffected. The full list of supported methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0ddddd60",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['bonferroni', 'sidak', 'holm', 'holm-sidak', 'fdr_bh', 'fdr_by', 'hommel', 'simes-hochberg']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from ambrosia.tools import multitest\n",
+    "\n",
+    "multitest.available_methods()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4339edb1",
+   "metadata": {},
+   "source": [
+    "## 4. Comparing the methods\n",
+    "\n",
+    "The table puts the raw p-values next to every corrected version. All methods make the p-values\n",
+    "larger (more conservative); they differ in *how much*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5bb49cbb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>metric</th>\n",
+       "      <th>raw</th>\n",
+       "      <th>bonferroni</th>\n",
+       "      <th>holm</th>\n",
+       "      <th>holm-sidak</th>\n",
+       "      <th>sidak</th>\n",
+       "      <th>fdr_bh</th>\n",
+       "      <th>fdr_by</th>\n",
+       "      <th>hommel</th>\n",
+       "      <th>simes-hochberg</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>metric_1</td>\n",
+       "      <td>0.1387</td>\n",
+       "      <td>0.8319</td>\n",
+       "      <td>0.5546</td>\n",
+       "      <td>0.4495</td>\n",
+       "      <td>0.5916</td>\n",
+       "      <td>0.2773</td>\n",
+       "      <td>0.6794</td>\n",
+       "      <td>0.5546</td>\n",
+       "      <td>0.5546</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>metric_2</td>\n",
+       "      <td>0.4573</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.8401</td>\n",
+       "      <td>0.9744</td>\n",
+       "      <td>0.6859</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.8861</td>\n",
+       "      <td>0.8861</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>metric_3</td>\n",
+       "      <td>0.8861</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.9045</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.8861</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.8861</td>\n",
+       "      <td>0.8861</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>metric_4</td>\n",
+       "      <td>0.0320</td>\n",
+       "      <td>0.1922</td>\n",
+       "      <td>0.1602</td>\n",
+       "      <td>0.1502</td>\n",
+       "      <td>0.1774</td>\n",
+       "      <td>0.0961</td>\n",
+       "      <td>0.2354</td>\n",
+       "      <td>0.1602</td>\n",
+       "      <td>0.1602</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>metric_5</td>\n",
+       "      <td>0.6910</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.9045</td>\n",
+       "      <td>0.9991</td>\n",
+       "      <td>0.8293</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>0.8861</td>\n",
+       "      <td>0.8861</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>metric_6</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     metric     raw  bonferroni    holm  ...  fdr_bh  fdr_by  hommel  simes-hochberg\n",
+       "0  metric_1  0.1387      0.8319  0.5546  ...  0.2773  0.6794  0.5546          0.5546\n",
+       "1  metric_2  0.4573      1.0000  1.0000  ...  0.6859  1.0000  0.8861          0.8861\n",
+       "2  metric_3  0.8861      1.0000  1.0000  ...  0.8861  1.0000  0.8861          0.8861\n",
+       "3  metric_4  0.0320      0.1922  0.1602  ...  0.0961  0.2354  0.1602          0.1602\n",
+       "4  metric_5  0.6910      1.0000  1.0000  ...  0.8293  1.0000  0.8861          0.8861\n",
+       "5  metric_6  0.0000      0.0000  0.0000  ...  0.0000  0.0000  0.0000          0.0000\n",
+       "\n",
+       "[6 rows x 10 columns]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "methods = [\"bonferroni\", \"holm\", \"holm-sidak\", \"sidak\", \"fdr_bh\", \"fdr_by\", \"hommel\", \"simes-hochberg\"]\n",
+    "\n",
+    "comparison = pd.DataFrame({\"metric\": raw[\"metric name\"].values, \"raw\": raw[\"pvalue\"].values})\n",
+    "for m in methods:\n",
+    "    res = tester.run(\"absolute\", method=\"theory\", correction_method=m, as_table=True)\n",
+    "    comparison[m] = res[\"pvalue\"].values\n",
+    "comparison.round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b953ef3e",
+   "metadata": {},
+   "source": [
+    "## 5. Which method should I use?\n",
+    "\n",
+    "* **Family-wise error rate (FWER)** - `bonferroni`, `holm`, `holm-sidak`, `sidak`, `hommel`,\n",
+    "  `simes-hochberg`. They bound the probability of making *any* false positive. `bonferroni` is\n",
+    "  the simplest but most conservative; `holm` and the step-wise methods reject at least as much,\n",
+    "  so you keep more power.\n",
+    "* **False discovery rate (FDR)** - `fdr_bh` (Benjamini-Hochberg) and `fdr_by`\n",
+    "  (Benjamini-Yekutieli). They control the expected *share* of false positives among the metrics\n",
+    "  you call significant - usually the right trade-off for a dashboard with many metrics.\n",
+    "\n",
+    "How many metrics stay significant at 5% under each approach?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "98c3a890",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "none       : 2 significant metric(s) at 0.05\n",
+      "bonferroni : 1 significant metric(s) at 0.05\n",
+      "holm       : 1 significant metric(s) at 0.05\n",
+      "fdr_bh     : 1 significant metric(s) at 0.05\n"
+     ]
+    }
+   ],
+   "source": [
+    "alpha = 0.05\n",
+    "for label, cm in [(\"none\", None), (\"bonferroni\", \"bonferroni\"), (\"holm\", \"holm\"), (\"fdr_bh\", \"fdr_bh\")]:\n",
+    "    res = tester.run(\"absolute\", method=\"theory\", correction_method=cm, as_table=True)\n",
+    "    n_sig = int((res[\"pvalue\"] < alpha).sum())\n",
+    "    print(f\"{label:11s}: {n_sig} significant metric(s) at {alpha}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50bcd80c",
+   "metadata": {},
+   "source": [
+    "`none` reports 2 (one is the false positive). Every correction removes the false positive,\n",
+    "while Holm and Benjamini-Hochberg still keep the genuine `metric_6`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "254369d7",
+   "metadata": {},
+   "source": [
+    "## 6. What happens to confidence intervals?\n",
+    "\n",
+    "For the constant-scaling methods (`bonferroni`, `sidak`) the confidence intervals are\n",
+    "**widened** to stay consistent with the corrected decision. The step-wise methods (Holm, FDR,\n",
+    "...) adjust **only the p-values** and leave the intervals at their nominal level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a05a1a0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>metric</th>\n",
+       "      <th>CI (none)</th>\n",
+       "      <th>CI (bonferroni - wider)</th>\n",
+       "      <th>CI (holm - same as none)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>metric_1</td>\n",
+       "      <td>(-0.0155, 0.1111)</td>\n",
+       "      <td>(-0.0373, 0.133)</td>\n",
+       "      <td>(-0.0155, 0.1111)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>metric_2</td>\n",
+       "      <td>(-0.0838, 0.0377)</td>\n",
+       "      <td>(-0.1048, 0.0587)</td>\n",
+       "      <td>(-0.0838, 0.0377)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>metric_3</td>\n",
+       "      <td>(-0.0664, 0.0573)</td>\n",
+       "      <td>(-0.0878, 0.0787)</td>\n",
+       "      <td>(-0.0664, 0.0573)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>metric_4</td>\n",
+       "      <td>(-0.1285, -0.0058)</td>\n",
+       "      <td>(-0.1497, 0.0154)</td>\n",
+       "      <td>(-0.1285, -0.0058)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>metric_5</td>\n",
+       "      <td>(-0.0486, 0.0733)</td>\n",
+       "      <td>(-0.0697, 0.0944)</td>\n",
+       "      <td>(-0.0486, 0.0733)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>metric_6</td>\n",
+       "      <td>(0.1358, 0.2583)</td>\n",
+       "      <td>(0.1146, 0.2795)</td>\n",
+       "      <td>(0.1358, 0.2583)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     metric  ... CI (holm - same as none)\n",
+       "0  metric_1  ...        (-0.0155, 0.1111)\n",
+       "1  metric_2  ...        (-0.0838, 0.0377)\n",
+       "2  metric_3  ...        (-0.0664, 0.0573)\n",
+       "3  metric_4  ...       (-0.1285, -0.0058)\n",
+       "4  metric_5  ...        (-0.0486, 0.0733)\n",
+       "5  metric_6  ...         (0.1358, 0.2583)\n",
+       "\n",
+       "[6 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "none_ci = tester.run(\"absolute\", method=\"theory\", correction_method=None, as_table=True)\n",
+    "bonf_ci = tester.run(\"absolute\", method=\"theory\", correction_method=\"bonferroni\", as_table=True)\n",
+    "holm_ci = tester.run(\"absolute\", method=\"theory\", correction_method=\"holm\", as_table=True)\n",
+    "\n",
+    "pd.DataFrame({\n",
+    "    \"metric\": none_ci[\"metric name\"].values,\n",
+    "    \"CI (none)\": list(none_ci[\"confidence_interval\"]),\n",
+    "    \"CI (bonferroni - wider)\": list(bonf_ci[\"confidence_interval\"]),\n",
+    "    \"CI (holm - same as none)\": list(holm_ci[\"confidence_interval\"]),\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11eed334",
+   "metadata": {},
+   "source": [
+    "## 7. Aliases and summary\n",
+    "\n",
+    "Friendly aliases are accepted, e.g. `\"benjamini-hochberg\"` == `\"fdr_bh\"` and\n",
+    "`\"benjamini-yekutieli\"` == `\"fdr_by\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f5f3c55f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "alias = tester.run(\"absolute\", method=\"theory\", correction_method=\"benjamini-hochberg\", as_table=True)\n",
+    "canonical = tester.run(\"absolute\", method=\"theory\", correction_method=\"fdr_bh\", as_table=True)\n",
+    "bool((alias[\"pvalue\"].values == canonical[\"pvalue\"].values).all())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cf3371c",
+   "metadata": {},
+   "source": [
+    "**Rule of thumb**\n",
+    "\n",
+    "| Situation | Suggested `correction_method` |\n",
+    "| --- | --- |\n",
+    "| One metric, two groups | `None` (nothing to correct) |\n",
+    "| A few key metrics, must avoid any false positive | `\"holm\"` (or `\"bonferroni\"`) |\n",
+    "| Many metrics on a dashboard | `\"fdr_bh\"` |\n",
+    "| You also need corrected confidence intervals | `\"bonferroni\"` or `\"sidak\"` |\n",
+    "\n",
+    "Switching the correction is a one-argument change to `Tester.run`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_multitest.py
+++ b/tests/test_multitest.py
@@ -1,0 +1,265 @@
+from typing import List
+
+import numpy as np
+import pytest
+
+from ambrosia.tools import multitest as mt
+from ambrosia.tools.configs import MultipleTestingCorrection
+
+ALL_METHODS: List[str] = [
+    "bonferroni",
+    "sidak",
+    "holm",
+    "holm-sidak",
+    "fdr_bh",
+    "fdr_by",
+    "hommel",
+    "simes-hochberg",
+]
+
+# statsmodels is used purely as a cross-check oracle for the native implementation.
+try:
+    from statsmodels.stats.multitest import multipletests
+
+    _HAS_STATSMODELS = True
+except Exception:  # pragma: no cover - statsmodels is a hard dependency in practice
+    _HAS_STATSMODELS = False
+
+requires_statsmodels = pytest.mark.skipif(not _HAS_STATSMODELS, reason="statsmodels is not installed")
+
+
+# Sorted reference vector with hand-computed expectations (family size m = 5).
+HANDP = np.array([0.001, 0.008, 0.039, 0.041, 0.9])
+HAND_EXPECTED = {
+    # bonferroni: min(m * p, 1)
+    "bonferroni": [0.005, 0.04, 0.195, 0.205, 1.0],
+    # holm step-down: cummax of (m - i + 1) * p_(i)
+    "holm": [0.005, 0.032, 0.117, 0.117, 0.9],
+    # Benjamini-Hochberg step-up: cummin (from top) of (m / i) * p_(i)
+    "fdr_bh": [0.005, 0.02, 0.05125, 0.05125, 0.9],
+    # Hochberg step-up: cummin (from top) of (m - i + 1) * p_(i)
+    "simes-hochberg": [0.005, 0.032, 0.082, 0.082, 0.9],
+}
+
+ORACLE_VECTORS = [
+    np.array([0.001, 0.008, 0.039, 0.041, 0.9]),
+    np.array([0.04, 0.04, 0.04, 0.04]),  # ties
+    np.array([0.5]),  # singleton
+    np.array([0.0, 0.0, 1.0, 1.0]),  # boundary values
+    np.array([1e-9, 0.2, 0.7, 0.999, 0.5, 0.03]),
+    np.random.default_rng(7).uniform(0, 1, 37),
+    np.random.default_rng(8).uniform(0, 1, 128),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", list(HAND_EXPECTED))
+def test_adjust_matches_hand_computed(method):
+    """
+    Native output equals independently hand-computed values for clean methods.
+    """
+    got = mt.adjust_pvalues(HANDP, method)
+    np.testing.assert_allclose(got, HAND_EXPECTED[method], atol=1e-9)
+
+
+@requires_statsmodels
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_METHODS)
+@pytest.mark.parametrize("vec_id", range(len(ORACLE_VECTORS)))
+def test_adjust_matches_statsmodels(method, vec_id):
+    """
+    Native output matches statsmodels.multipletests for every method and vector.
+    """
+    vec = ORACLE_VECTORS[vec_id]
+    # statsmodels' sidak/holm-sidak use log1p(-p), which warns at p == 1; harmless here.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        _, expected, _, _ = multipletests(vec, method=method)
+    got = mt.adjust_pvalues(vec, method)
+    np.testing.assert_allclose(got, expected, atol=1e-12, rtol=0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_adjusted_within_unit_interval_and_at_least_raw(method):
+    """
+    Adjusted p-values stay in [0, 1] and are never smaller than the raw values.
+    """
+    p = np.random.default_rng(123).uniform(0, 1, 60)
+    adj = mt.adjust_pvalues(p, method)
+    assert np.all(adj >= -1e-12)
+    assert np.all(adj <= 1 + 1e-12)
+    assert np.all(adj >= p - 1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_monotone_in_rank(method):
+    """
+    Adjusted p-values are non-decreasing in the rank of the raw p-value.
+    """
+    p = np.random.default_rng(321).uniform(0, 1, 40)
+    adj = mt.adjust_pvalues(p, method)
+    order = np.argsort(p, kind="mergesort")
+    assert np.all(np.diff(adj[order]) >= -1e-12)
+
+
+@pytest.mark.unit
+def test_method_conservativeness_ordering():
+    """
+    Known dominance relations between the supported procedures.
+
+    A fixed vector with small leading p-values is used so each inequality is
+    strict somewhere: a degenerate vector (everything saturating to 1.0) would
+    make the relations vacuously true and could hide, e.g., a Holm step-up /
+    step-down swap or a Hommel / Hochberg mix-up.
+    """
+    p = np.array([0.001, 0.005, 0.012, 0.025, 0.04, 0.06, 0.15, 0.35, 0.6, 0.85])
+    res = {m: mt.adjust_pvalues(p, m) for m in ALL_METHODS}
+    tol = 1e-12
+
+    def dominates(smaller: np.ndarray, larger: np.ndarray) -> None:
+        # ``smaller`` <= ``larger`` everywhere and strictly smaller somewhere.
+        assert np.all(smaller <= larger + tol)
+        assert np.any(smaller < larger - tol)
+
+    # FWER step-down family.
+    dominates(res["holm"], res["bonferroni"])
+    dominates(res["sidak"], res["bonferroni"])
+    dominates(res["holm-sidak"], res["holm"])
+    # Step-up dominates step-down; Hommel dominates Hochberg.
+    dominates(res["simes-hochberg"], res["holm"])
+    dominates(res["hommel"], res["simes-hochberg"])
+    # FDR control is less conservative than Holm; BY is more conservative than BH.
+    dominates(res["fdr_bh"], res["holm"])
+    dominates(res["fdr_bh"], res["fdr_by"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_single_hypothesis_is_identity(method):
+    """
+    With one hypothesis every method returns the raw p-value unchanged.
+    """
+    for p in [0.0, 0.01, 0.5, 0.99, 1.0]:
+        np.testing.assert_allclose(mt.adjust_pvalues(np.array([p]), method), [p], atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_nan_preserved_and_counted_in_family(method):
+    """
+    Entries that are NaN pass through in place but still count toward the family
+    size (matching R's p.adjust); only the present p-values are ranked. The
+    present positions therefore match treating the NaN slot as a neutral p = 1.
+    """
+    p = np.array([0.01, np.nan, 0.02, 0.04])
+    adj = mt.adjust_pvalues(p, method)
+    assert np.isnan(adj[1])
+    expected_full = mt.adjust_pvalues(np.array([0.01, 1.0, 0.02, 0.04]), method)
+    np.testing.assert_allclose(adj[[0, 2, 3]], expected_full[[0, 2, 3]], atol=1e-12)
+
+
+@pytest.mark.unit
+def test_all_nan_returns_all_nan():
+    adj = mt.adjust_pvalues(np.array([np.nan, np.nan]), "holm")
+    assert np.all(np.isnan(adj))
+
+
+@pytest.mark.unit
+def test_empty_input_returns_empty():
+    adj = mt.adjust_pvalues(np.array([]), "fdr_bh")
+    assert adj.shape == (0,)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_permutation_equivariance(method):
+    """
+    Adjusting then permuting equals permuting then adjusting.
+    """
+    rng = np.random.default_rng(55)
+    p = rng.uniform(0, 1, 25)
+    perm = rng.permutation(25)
+    adj = mt.adjust_pvalues(p, method)
+    adj_perm = mt.adjust_pvalues(p[perm], method)
+    np.testing.assert_allclose(adj_perm, adj[perm], atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [[-0.01, 0.2], [0.3, 1.5], [np.inf, 0.1]])
+def test_out_of_range_raises(bad):
+    with pytest.raises(ValueError):
+        mt.adjust_pvalues(np.array(bad), "holm")
+
+
+@pytest.mark.unit
+def test_two_dimensional_raises():
+    with pytest.raises(ValueError):
+        mt.adjust_pvalues(np.array([[0.1, 0.2], [0.3, 0.4]]), "holm")
+
+
+@pytest.mark.unit
+def test_invalid_method_raises():
+    with pytest.raises(ValueError):
+        mt.adjust_pvalues(np.array([0.1, 0.2]), "definitely-not-a-method")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [
+        ("benjamini-hochberg", "fdr_bh"),
+        ("BH", "fdr_bh"),
+        ("benjamini-yekutieli", "fdr_by"),
+        ("BY", "fdr_by"),
+        ("hochberg", "simes-hochberg"),
+        ("  Holm  ", "holm"),
+    ],
+)
+def test_alias_normalization(alias, canonical):
+    assert mt.normalize_method(alias) == canonical
+    np.testing.assert_allclose(mt.adjust_pvalues(HANDP, alias), mt.adjust_pvalues(HANDP, canonical), atol=1e-12)
+
+
+@pytest.mark.unit
+def test_validate_method_returns_canonical():
+    assert mt.validate_method("BH") == "fdr_bh"
+    with pytest.raises(ValueError):
+        mt.validate_method("nope")
+
+
+@pytest.mark.unit
+def test_available_methods_matches_enum():
+    assert set(mt.available_methods()) == {member.value for member in MultipleTestingCorrection}
+    assert set(mt.available_methods()) == set(ALL_METHODS)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "method,correctable",
+    [
+        ("bonferroni", True),
+        ("sidak", True),
+        ("holm", False),
+        ("holm-sidak", False),
+        ("fdr_bh", False),
+        ("fdr_by", False),
+        ("hommel", False),
+        ("simes-hochberg", False),
+    ],
+)
+def test_is_ci_correctable(method, correctable):
+    assert mt.is_ci_correctable(method) is correctable
+
+
+@pytest.mark.unit
+def test_alpha_for_confidence_interval():
+    alpha = np.array([0.05, 0.1])
+    m = 4
+    np.testing.assert_allclose(mt.alpha_for_confidence_interval(alpha, "bonferroni", m), alpha / m)
+    np.testing.assert_allclose(mt.alpha_for_confidence_interval(alpha, "sidak", m), 1 - (1 - alpha) ** (1 / m))
+    for method in ["holm", "holm-sidak", "fdr_bh", "fdr_by", "hommel", "simes-hochberg"]:
+        np.testing.assert_allclose(mt.alpha_for_confidence_interval(alpha, method, m), alpha)
+    # Sidak's interval level sits strictly between Bonferroni and the nominal level.
+    sidak_alpha = mt.alpha_for_confidence_interval(alpha, "sidak", m)
+    assert np.all(sidak_alpha > alpha / m) and np.all(sidak_alpha < alpha)

--- a/tests/test_tester.py
+++ b/tests/test_tester.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from ambrosia.tester import Tester, test
+from ambrosia.tools import multitest as mt
 from ambrosia.tools.stat_criteria import TtestIndCriterion, TtestRelCriterion
 
 
@@ -461,3 +462,367 @@ def test_metric_func_bootstrap(results_ltv_retention_conversions):
     assert "pvalue" in result[0]
     assert "effect" in result[0]
     assert "confidence_interval" in result[0]
+
+
+def _two_group_frame() -> pd.DataFrame:
+    """
+    Deterministic two-group, two-metric frame with UNEQUAL within-group variances.
+
+    The unequal spread makes the pinned p-values specific to the Welch t-test
+    (the default criterion); they would change if the variance handling regressed
+    to a pooled/Student t-test.
+    """
+    return pd.DataFrame(
+        {
+            "group": ["A"] * 10 + ["B"] * 10,
+            "m1": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] + [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+            "m2": [5, 5, 5, 5, 5, 6, 6, 6, 6, 6] + [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        }
+    )
+
+
+def _three_group_frame() -> pd.DataFrame:
+    """
+    Deterministic three-group, one-metric frame. The family size becomes
+    m = C(3, 2) * 1 = 3, exercising both the pair enumeration and the p-value
+    clip-at-1 boundary (the A-vs-B pair has raw p * 3 > 1).
+    """
+    return pd.DataFrame(
+        {
+            "group": ["A"] * 10 + ["B"] * 10 + ["C"] * 10,
+            "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            + [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+            + [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+        }
+    )
+
+
+@pytest.mark.unit
+def test_bonferroni_backward_compat_characterization():
+    """
+    Lock the EXACT current Bonferroni output (absolute effect) before the multitest
+    refactor. With two metrics and two groups the family size is m = C(2, 2) * 2 = 2:
+    p-values are multiplied by 2 (clipped at 1), confidence intervals are built at
+    alpha / 2, and the reported first type error is restored to the nominal level.
+    The default ``correction_method`` is ``"bonferroni"``, so default == explicit.
+    Backward-compatibility guard: must keep passing unchanged after the refactor.
+    """
+    tester = Tester(
+        dataframe=_two_group_frame(),
+        column_groups="group",
+        metrics=["m1", "m2"],
+        first_type_errors=0.05,
+    )
+    res_bonf = tester.run("absolute", method="theory", correction_method="bonferroni", as_table=False)
+    res_none = tester.run("absolute", method="theory", correction_method=None, as_table=False)
+    res_default = tester.run("absolute", method="theory", as_table=False)
+    bonf = {r["metric name"]: r for r in res_bonf}
+    none = {r["metric name"]: r for r in res_none}
+    default = {r["metric name"]: r for r in res_default}
+
+    # Exact uncorrected Welch p-values (differ from Student's t for this frame).
+    assert none["m1"]["pvalue"] == pytest.approx(0.0230712838, abs=1e-9)
+    assert none["m2"]["pvalue"] == pytest.approx(0.0679387323, abs=1e-9)
+    # Exact Bonferroni-corrected p-values.
+    assert bonf["m1"]["pvalue"] == pytest.approx(0.0461425675, abs=1e-9)
+    assert bonf["m2"]["pvalue"] == pytest.approx(0.1358774645, abs=1e-9)
+
+    for metric in ["m1", "m2"]:
+        # The default correction_method is "bonferroni": default == explicit.
+        assert default[metric]["pvalue"] == pytest.approx(bonf[metric]["pvalue"], abs=1e-12)
+        # Bonferroni p-value == min(raw * m, 1).
+        assert bonf[metric]["pvalue"] == pytest.approx(min(none[metric]["pvalue"] * 2, 1.0), abs=1e-12)
+        # Reported first type error is restored to the nominal level.
+        assert float(np.ravel(bonf[metric]["first_type_error"])[0]) == pytest.approx(0.05)
+        # Corrected confidence interval is strictly wider (built at alpha / m).
+        assert bonf[metric]["confidence_interval"][0] < none[metric]["confidence_interval"][0]
+        assert bonf[metric]["confidence_interval"][1] > none[metric]["confidence_interval"][1]
+
+
+@pytest.mark.unit
+def test_bonferroni_characterization_as_table():
+    """
+    Lock the ``as_table=True`` output (the primary path; the list-of-dicts output is
+    derived from it): the column set and the restored nominal first_type_error column.
+    """
+    tester = Tester(
+        dataframe=_two_group_frame(),
+        column_groups="group",
+        metrics=["m1", "m2"],
+        first_type_errors=0.05,
+    )
+    table = tester.run("absolute", method="theory", correction_method="bonferroni", as_table=True)
+    assert isinstance(table, pd.DataFrame)
+    assert list(table.columns) == [
+        "first_type_error",
+        "pvalue",
+        "effect",
+        "confidence_interval",
+        "metric name",
+        "group A label",
+        "group B label",
+    ]
+    assert list(table["first_type_error"]) == [0.05, 0.05]
+    pvals = dict(zip(table["metric name"], table["pvalue"]))
+    assert pvals["m1"] == pytest.approx(0.0461425675, abs=1e-9)
+    assert pvals["m2"] == pytest.approx(0.1358774645, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_bonferroni_characterization_relative():
+    """
+    Lock current Bonferroni behavior for the relative effect type (delta-method
+    p-value path). Family size m = 2, so p-values double (clipped at 1).
+    """
+    tester = Tester(
+        dataframe=_two_group_frame(),
+        column_groups="group",
+        metrics=["m1", "m2"],
+        first_type_errors=0.05,
+    )
+    none = {r["metric name"]: r for r in tester.run("relative", "theory", correction_method=None, as_table=False)}
+    bonf = {
+        r["metric name"]: r for r in tester.run("relative", "theory", correction_method="bonferroni", as_table=False)
+    }
+    assert none["m1"]["pvalue"] == pytest.approx(0.0239676798, abs=1e-9)
+    assert none["m2"]["pvalue"] == pytest.approx(0.0316317147, abs=1e-9)
+    for metric in ["m1", "m2"]:
+        assert bonf[metric]["pvalue"] == pytest.approx(min(none[metric]["pvalue"] * 2, 1.0), abs=1e-12)
+
+
+@pytest.mark.unit
+def test_bonferroni_three_groups_clip_characterization():
+    """
+    Three groups, one metric => m = C(3, 2) = 3 hypotheses. Locks the pair
+    enumeration, the exact 3x scaling for non-clipping pairs, and the clip-at-1
+    boundary (the A-vs-B pair has raw p * 3 > 1).
+    """
+    tester = Tester(
+        dataframe=_three_group_frame(),
+        column_groups="group",
+        metrics=["x"],
+        first_type_errors=0.05,
+    )
+    none = tester.run("absolute", "theory", correction_method=None, as_table=False)
+    bonf = tester.run("absolute", "theory", correction_method="bonferroni", as_table=False)
+    assert len(none) == 3 and len(bonf) == 3
+    none_by = {(r["group A label"], r["group B label"]): r["pvalue"] for r in none}
+    bonf_by = {(r["group A label"], r["group B label"]): r["pvalue"] for r in bonf}
+    assert set(none_by) == {("A", "B"), ("A", "C"), ("B", "C")}
+    # Each corrected p-value equals min(raw * 3, 1).
+    for pair, raw_p in none_by.items():
+        assert bonf_by[pair] == pytest.approx(min(raw_p * 3, 1.0), abs=1e-12)
+    # A-vs-B clips to 1.0; the well-separated pairs do not.
+    assert bonf_by[("A", "B")] == pytest.approx(1.0, abs=1e-12)
+    assert bonf_by[("A", "C")] < 1.0
+    assert bonf_by[("B", "C")] < 1.0
+
+
+@pytest.mark.unit
+def test_single_metric_no_correction_characterization():
+    """
+    With a single hypothesis (one metric, two groups) no correction is applied,
+    so Bonferroni, the default and ``None`` must all yield identical p-values.
+    """
+    tester = Tester(dataframe=_two_group_frame(), column_groups="group", metrics=["m1"], first_type_errors=0.05)
+    p_bonf = tester.run("absolute", method="theory", correction_method="bonferroni", as_table=False)[0]["pvalue"]
+    p_none = tester.run("absolute", method="theory", correction_method=None, as_table=False)[0]["pvalue"]
+    assert p_bonf == pytest.approx(p_none, abs=1e-12)
+    assert p_none == pytest.approx(0.0230712838, abs=1e-9)
+
+
+NEW_CORRECTION_METHODS = ["sidak", "holm", "holm-sidak", "fdr_bh", "fdr_by", "hommel", "simes-hochberg"]
+ALL_CORRECTION_METHODS = ["bonferroni"] + NEW_CORRECTION_METHODS
+
+
+def _three_group_two_metric_frame() -> pd.DataFrame:
+    """
+    Deterministic three-group, two-metric frame (family size m = C(3, 2) * 2 = 6)
+    with a spread of effect sizes, so the corrected p-values vary across methods.
+    """
+    rng = np.random.default_rng(2024)
+    n = 150
+    return pd.DataFrame(
+        {
+            "group": ["A"] * n + ["B"] * n + ["C"] * n,
+            "x": np.r_[rng.normal(0.0, 1.0, n), rng.normal(0.3, 1.0, n), rng.normal(0.15, 1.0, n)],
+            "y": np.r_[rng.normal(10.0, 3.0, n), rng.normal(10.4, 3.0, n), rng.normal(9.7, 3.0, n)],
+        }
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("effect_type", ["absolute", "relative"])
+@pytest.mark.parametrize("method", ALL_CORRECTION_METHODS)
+def test_correction_method_wires_multitest(method, effect_type):
+    """
+    The Tester applies the multitest module to the family of raw p-values:
+    corrected p-values match the module output, the reported first type error
+    stays nominal, and only the constant-scaling methods (Bonferroni, Sidak)
+    widen the confidence intervals while step-wise methods leave them nominal.
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=0.05,
+    )
+    raw = tester.run(effect_type, method="theory", correction_method=None, as_table=True)
+    corrected = tester.run(effect_type, method="theory", correction_method=method, as_table=True)
+    np.testing.assert_allclose(corrected["pvalue"].values, mt.adjust_pvalues(raw["pvalue"].values, method), atol=1e-12)
+    np.testing.assert_allclose(corrected["first_type_error"].values, raw["first_type_error"].values)
+    if mt.is_ci_correctable(method):
+        assert list(corrected["confidence_interval"]) != list(raw["confidence_interval"])
+    else:
+        assert list(corrected["confidence_interval"]) == list(raw["confidence_interval"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ALL_CORRECTION_METHODS)
+def test_correction_is_more_conservative_than_raw(method):
+    """
+    Every supported correction yields p-values no smaller than the uncorrected ones.
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=0.05,
+    )
+    raw = tester.run("absolute", method="theory", correction_method=None, as_table=True)["pvalue"].values
+    corrected = tester.run("absolute", method="theory", correction_method=method, as_table=True)["pvalue"].values
+    assert np.all(corrected >= raw - 1e-12)
+
+
+@pytest.mark.unit
+def test_correction_relative_ordering():
+    """
+    At the Tester level: raw <= Holm <= Bonferroni and Benjamini-Hochberg <= Holm
+    (results across runs share the same row order, so they compare element-wise).
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=0.05,
+    )
+
+    def pvalues(correction):
+        return tester.run("absolute", method="theory", correction_method=correction, as_table=True)["pvalue"].values
+
+    raw, bonf, holm, bh = pvalues(None), pvalues("bonferroni"), pvalues("holm"), pvalues("fdr_bh")
+    tol = 1e-12
+    assert np.all(raw <= holm + tol)
+    assert np.all(holm <= bonf + tol)
+    assert np.all(bh <= holm + tol)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", NEW_CORRECTION_METHODS)
+def test_single_hypothesis_correction_is_noop(method):
+    """
+    With a single hypothesis every method equals the uncorrected result.
+    """
+    tester = Tester(dataframe=_two_group_frame(), column_groups="group", metrics=["m1"], first_type_errors=0.05)
+    p_none = tester.run("absolute", method="theory", correction_method=None, as_table=False)[0]["pvalue"]
+    p_corr = tester.run("absolute", method="theory", correction_method=method, as_table=False)[0]["pvalue"]
+    assert p_corr == pytest.approx(p_none, abs=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ["holm", "fdr_bh"])
+def test_correction_as_table_matches_records(method):
+    """
+    The as_table=True and as_table=False outputs carry the same corrected p-values.
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=0.05,
+    )
+    table = tester.run("absolute", method="theory", correction_method=method, as_table=True)
+    records = tester.run("absolute", method="theory", correction_method=method, as_table=False)
+    np.testing.assert_allclose(table["pvalue"].values, [record["pvalue"] for record in records], atol=1e-12)
+
+
+@pytest.mark.unit
+def test_invalid_correction_method_raises():
+    """
+    An unknown correction method raises ValueError when correction is applied.
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=0.05,
+    )
+    with pytest.raises(ValueError):
+        tester.run("absolute", method="theory", correction_method="not-a-method")
+
+
+@pytest.mark.unit
+def test_correction_with_nan_pvalue_counts_full_family():
+    """
+    A degenerate (constant) metric yields a NaN p-value. It still counts toward
+    the family size, so the surviving metric is corrected by the full family of 2
+    (matching the pre-refactor Bonferroni behavior), and the NaN passes through.
+    """
+    frame = pd.DataFrame(
+        {
+            "group": ["A"] * 10 + ["B"] * 10,
+            "m_ok": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] + [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+            "m_const": [5] * 20,
+        }
+    )
+    tester = Tester(dataframe=frame, column_groups="group", metrics=["m_ok", "m_const"], first_type_errors=0.05)
+    raw = {
+        r["metric name"]: r["pvalue"] for r in tester.run("absolute", "theory", correction_method=None, as_table=False)
+    }
+    bonf = {
+        r["metric name"]: r["pvalue"]
+        for r in tester.run("absolute", "theory", correction_method="bonferroni", as_table=False)
+    }
+    assert np.isnan(raw["m_const"]) and np.isnan(bonf["m_const"])
+    assert bonf["m_ok"] == pytest.approx(min(raw["m_ok"] * 2, 1.0), abs=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ["holm", "fdr_bh"])
+def test_correction_with_alpha_vector_uses_hypothesis_family(method):
+    """
+    With several first type error levels the result table repeats each hypothesis
+    once per level, but a step-wise correction must use the hypothesis family
+    (size 6 here), not the flattened 12-row table. The corrected p-value of each
+    hypothesis is therefore the family-6 adjustment, shared across the levels.
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=[0.05, 0.1],
+    )
+    raw_family = tester.run("absolute", "theory", first_type_errors=0.05, correction_method=None, as_table=True)
+    corrected = tester.run("absolute", "theory", correction_method=method, as_table=True)
+    assert len(raw_family) == 6
+    assert len(corrected) == 12
+    assert sorted(np.unique(corrected["first_type_error"]).tolist()) == [0.05, 0.1]
+    expected = mt.adjust_pvalues(raw_family["pvalue"].values, method)  # family size 6
+    unique_corrected = corrected.drop_duplicates(subset=["group A label", "group B label", "metric name"])
+    np.testing.assert_allclose(unique_corrected["pvalue"].values, expected, atol=1e-12)
+
+
+@pytest.mark.unit
+def test_correction_alias_through_tester():
+    """
+    A correction alias passed to the Tester resolves to its canonical method.
+    """
+    tester = Tester(
+        dataframe=_three_group_two_metric_frame(),
+        column_groups="group",
+        metrics=["x", "y"],
+        first_type_errors=0.05,
+    )
+    alias = tester.run("absolute", "theory", correction_method="bh", as_table=True)["pvalue"].values
+    canonical = tester.run("absolute", "theory", correction_method="fdr_bh", as_table=True)["pvalue"].values
+    np.testing.assert_allclose(alias, canonical, atol=1e-12)


### PR DESCRIPTION
## What

Extends the `Tester`'s `correction_method` beyond Bonferroni with seven additional multiple-testing corrections:

- **Family-wise error rate (FWER):** `sidak`, `holm`, `holm-sidak`, `hommel`, `simes-hochberg`
- **False discovery rate (FDR):** `fdr_bh` (Benjamini-Hochberg), `fdr_by` (Benjamini-Yekutieli)

`bonferroni` stays the default and `None` disables correction. Friendly aliases (e.g. `benjamini-hochberg`) are accepted.

## Behaviour

- P-value adjustment is applied to the distinct hypothesis family (group-pair × metric), so the rank-based procedures stay correct even with several `first_type_errors` levels.
- For `bonferroni` and `sidak` the confidence intervals are widened to match; the step-wise methods adjust only the p-values and leave the intervals at the nominal level.
- **Backward compatible:** Bonferroni output is identical to before (locked by characterization tests), including the NaN-family case.

## Implementation

- New `ambrosia/tools/multitest.py` — native implementation, **no new runtime dependencies**; cross-validated against `statsmodels` and R's `p.adjust`.
- New `MultipleTestingCorrection` enum in `ambrosia/tools/configs.py`.

## Tests

- `tests/test_multitest.py` (125 tests) plus characterization and integration tests in `tests/test_tester.py`.
- Green on Python **3.9–3.13**; `pip install` of the built wheel verified.

## Docs

- New tutorial notebook `examples/13_multiple_testing_corrections.ipynb` (wired into the docs example list).
- `CHANGELOG.rst` 0.5.2 entry.

## Note

The version files are intentionally left at `0.5.1`; bump to `0.5.2` at release time.
