### PR TITLE
Fix Bayesian intervals in binary experiment design

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,25 @@
 Release Notes
 =============
 
+Version 0.5.3 (unreleased)
+---------------------------
+
+**Bug Fixes:**
+
+* Fixed binary experiment design with Bayesian intervals: the conjugate prior
+  parameters (``n_success_conjugate``, ``n_failure_conjugate``) for
+  ``interval_type="bayes_beta"`` now reach the interval computation in size,
+  effect and power design instead of raising ``TypeError``. Thanks to
+  Artem Vasin for the original fix (#45).
+
+* Fixed one-sided alternatives in the binary design power table: confidence
+  bounds are now built with the correct shape for simulation matrices, so
+  ``alternative="greater"``/``"less"`` no longer fails with a shape error.
+
+* Keyword arguments that collide with internally derived confidence interval
+  arguments (e.g. ``confidence_level``) now raise a clear ``ValueError``
+  instead of silently overriding the design parameters.
+
 Version 0.5.2 (01.06.2026)
 ---------------------------
 

--- a/ambrosia/tools/_lib/_bin_ci_aide.py
+++ b/ambrosia/tools/_lib/_bin_ci_aide.py
@@ -42,7 +42,7 @@ def __helper_calc_empirical_power(conf_interval: types.ManyIntervalType) -> np.n
 
 
 def __helper_bin_search_for_size(
-    interval_type: str, confidence_level: float, p_a: float, p_b: float, amount: int, power: float
+    interval_type: str, confidence_level: float, p_a: float, p_b: float, amount: int, power: float, **kwargs
 ) -> int:
     """
     Make binary search for size to gain given power.
@@ -81,6 +81,7 @@ def __helper_bin_search_for_size(
             "a_trials": trials,
             "b_trials": trials,
             "confidence_level": confidence_level,
+            **kwargs,
         }
         conf_interval: types.IntervalType = bi.BinomTwoSampleCI.confidence_interval(**binom_kwargs)
         return __helper_calc_empirical_power(conf_interval)
@@ -112,6 +113,7 @@ def __helper_bin_search_for_delta(
     amount: int,
     power: float,
     epsilon: float = 0.0001,
+    **kwargs,
 ) -> Optional[float]:
     """
     Make binary search for delta to gain given power for
@@ -154,6 +156,7 @@ def __helper_bin_search_for_delta(
             "a_trials": trials,
             "b_trials": trials,
             "confidence_level": confidence_level,
+            **kwargs,
         }
         conf_interval: types.IntervalType = bi.BinomTwoSampleCI.confidence_interval(**binom_kwargs)
         return __helper_calc_empirical_power(conf_interval)

--- a/ambrosia/tools/_lib/_bin_ci_aide.py
+++ b/ambrosia/tools/_lib/_bin_ci_aide.py
@@ -12,12 +12,38 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 import scipy.stats as sps
 
 from ambrosia import types
+
+
+def merge_ci_kwargs(derived_kwargs: Dict[str, Any], user_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Merge user keyword arguments into internally derived confidence
+    interval arguments, refusing to override the derived ones.
+
+    Parameters
+    ----------
+    derived_kwargs : Dict[str, Any]
+        Arguments computed from the design parameters.
+    user_kwargs : Dict[str, Any]
+        Extra arguments passed by the caller (e.g. conjugate prior
+        parameters or the hypothesis alternative).
+
+    Returns
+    -------
+    kwargs : Dict[str, Any]
+        Combined keyword arguments.
+    """
+    overlap = set(user_kwargs) & set(derived_kwargs)
+    if overlap:
+        raise ValueError(
+            f"Arguments {sorted(overlap)} are derived from the design parameters and cannot be passed directly"
+        )
+    return {**derived_kwargs, **user_kwargs}
 
 
 def __helper_calc_empirical_power(conf_interval: types.ManyIntervalType) -> np.ndarray:
@@ -74,15 +100,17 @@ def __helper_bin_search_for_size(
 
         sample_a = sps.binom.rvs(n=trials, p=p_a, size=amount)
         sample_b = sps.binom.rvs(n=trials, p=p_b, size=amount)
-        binom_kwargs = {
-            "interval_type": interval_type,
-            "a_success": sample_a,
-            "b_success": sample_b,
-            "a_trials": trials,
-            "b_trials": trials,
-            "confidence_level": confidence_level,
-            **kwargs,
-        }
+        binom_kwargs = merge_ci_kwargs(
+            {
+                "interval_type": interval_type,
+                "a_success": sample_a,
+                "b_success": sample_b,
+                "a_trials": trials,
+                "b_trials": trials,
+                "confidence_level": confidence_level,
+            },
+            kwargs,
+        )
         conf_interval: types.IntervalType = bi.BinomTwoSampleCI.confidence_interval(**binom_kwargs)
         return __helper_calc_empirical_power(conf_interval)
 
@@ -149,15 +177,17 @@ def __helper_bin_search_for_delta(
         sample_a = sps.binom.rvs(n=trials, p=p_a, size=amount)
         p_b: float = p_a - delta
         sample_b = sps.binom.rvs(n=trials, p=p_b, size=amount)
-        binom_kwargs = {
-            "interval_type": interval_type,
-            "a_success": sample_a,
-            "b_success": sample_b,
-            "a_trials": trials,
-            "b_trials": trials,
-            "confidence_level": confidence_level,
-            **kwargs,
-        }
+        binom_kwargs = merge_ci_kwargs(
+            {
+                "interval_type": interval_type,
+                "a_success": sample_a,
+                "b_success": sample_b,
+                "a_trials": trials,
+                "b_trials": trials,
+                "confidence_level": confidence_level,
+            },
+            kwargs,
+        )
         conf_interval: types.IntervalType = bi.BinomTwoSampleCI.confidence_interval(**binom_kwargs)
         return __helper_calc_empirical_power(conf_interval)
 

--- a/ambrosia/tools/bin_intervals.py
+++ b/ambrosia/tools/bin_intervals.py
@@ -390,6 +390,7 @@ def get_table_power_on_size_and_conversions(
     sample_sizes: Iterable[int] = (100,),
     amount: int = 10000,
     confidence_level: float = 0.95,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Table with power / empirical 1 type error = 1 - coverage, for fixed size and conversions.
@@ -432,6 +433,7 @@ def get_table_power_on_size_and_conversions(
                 "a_trials": trials,
                 "b_trials": trials,
                 "confidence_level": confidence_level,
+                **kwargs,
             }
             conf_interval: types.ManyIntervalType = BinomTwoSampleCI.confidence_interval(**binom_kwargs)
             power: np.ndarray = helper_dir.__helper_calc_empirical_power(conf_interval)
@@ -456,9 +458,9 @@ def get_table_power_on_size_and_delta(
     delta_values: Iterable[float] = None,
     delta_relative_values: Iterable[float] = None,
     interval_type: str = "wald",
-    # alternative: str = "two-sided",
     amount: int = 10000,
     as_numeric: bool = False,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Table with power / empirical 1 type error = 1 - coverage for fixed size and effect.
@@ -522,6 +524,7 @@ def get_table_power_on_size_and_delta(
                 "b_trials": trials,
                 "confidence_level": 1 - alpha,
                 #    "alternative": alternative,
+                **kwargs,
             }
             conf_interval: types.ManyIntervalType = BinomTwoSampleCI.confidence_interval(**binom_kwargs)
             power: np.ndarray = helper_dir.__helper_calc_empirical_power(conf_interval)
@@ -541,6 +544,7 @@ def iterate_for_sample_size(
     p_b_values: Iterable[float],
     grid_delta: Iterable[float],
     amount: int,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Iterate over params for different sample size
@@ -567,6 +571,7 @@ def iterate_for_sample_size(
                     p_b=p_b,
                     amount=amount,
                     power=power,
+                    **kwargs,
                 )
                 table.loc[delta, f"({alpha}; {beta})"] = trials
     return table
@@ -580,6 +585,7 @@ def get_table_sample_size_on_effect(
     delta_values: Iterable[float] = None,
     delta_relative_values: Iterable[float] = None,
     amount: int = 10000,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Table for sample sizes with given effect and errors.
@@ -628,7 +634,9 @@ def get_table_sample_size_on_effect(
         grid_delta: np.ndarray = [f"{np.round((x - 1) * 100, ROUND_DIGITS_PERCENT)}%" for x in delta_relative_values]
     if not np.all((p_b_values >= 0) & (p_b_values <= 1)):
         raise ValueError(f"Probability of success in group B must be positive, not {p_b_values}")
-    table = iterate_for_sample_size(interval_type, first_errors, second_errors, p_a, p_b_values, grid_delta, amount)
+    table = iterate_for_sample_size(
+        interval_type, first_errors, second_errors, p_a, p_b_values, grid_delta, amount, **kwargs
+    )
     return table
 
 
@@ -641,6 +649,7 @@ def iterate_for_delta(
     amount: int,
     delta_type: str,
     as_numeric: bool = False,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Helps to find effect for different params.
@@ -662,6 +671,7 @@ def iterate_for_delta(
                     trials=trials,
                     amount=amount,
                     power=power,
+                    **kwargs,
                 )
                 if delta is not None and delta_type == "relative":
                     if as_numeric:
@@ -681,6 +691,7 @@ def get_table_effect_on_sample_size(
     amount: int = 10000,
     delta_type: str = "relative",
     as_numeric: bool = False,
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Table for effects with given sample sizes and erros.
@@ -723,6 +734,6 @@ def get_table_effect_on_sample_size(
     if delta_type not in delta_types:
         raise ValueError(f"Delta type must be absolute relative, not {delta_type}")
     table: pd.DataFrame = iterate_for_delta(
-        interval_type, first_errors, second_errors, sample_sizes, p_a, amount, delta_type, as_numeric
+        interval_type, first_errors, second_errors, sample_sizes, p_a, amount, delta_type, as_numeric, **kwargs
     )
     return table

--- a/ambrosia/tools/bin_intervals.py
+++ b/ambrosia/tools/bin_intervals.py
@@ -426,15 +426,17 @@ def get_table_power_on_size_and_conversions(
         for p_b in p_b_values:
             sample_a = sps.binom.rvs(n=trials, p=p_a, size=(amount, len(sample_sizes)))
             sample_b = sps.binom.rvs(n=trials, p=p_b, size=(amount, len(sample_sizes)))
-            binom_kwargs = {
-                "interval_type": interval_type,
-                "a_success": sample_a,
-                "b_success": sample_b,
-                "a_trials": trials,
-                "b_trials": trials,
-                "confidence_level": confidence_level,
-                **kwargs,
-            }
+            binom_kwargs = helper_dir.merge_ci_kwargs(
+                {
+                    "interval_type": interval_type,
+                    "a_success": sample_a,
+                    "b_success": sample_b,
+                    "a_trials": trials,
+                    "b_trials": trials,
+                    "confidence_level": confidence_level,
+                },
+                kwargs,
+            )
             conf_interval: types.ManyIntervalType = BinomTwoSampleCI.confidence_interval(**binom_kwargs)
             power: np.ndarray = helper_dir.__helper_calc_empirical_power(conf_interval)
             powers_array.append(power)
@@ -516,16 +518,17 @@ def get_table_power_on_size_and_delta(
     for alpha in first_errors:
         for p_b, delta in zip(p_b_values, grid_delta):
             sample_b = sps.binom.rvs(n=trials, p=p_b, size=(amount, trials.shape[0]))
-            binom_kwargs = {
-                "interval_type": interval_type,
-                "a_success": sample_a,
-                "b_success": sample_b,
-                "a_trials": trials,
-                "b_trials": trials,
-                "confidence_level": 1 - alpha,
-                #    "alternative": alternative,
-                **kwargs,
-            }
+            binom_kwargs = helper_dir.merge_ci_kwargs(
+                {
+                    "interval_type": interval_type,
+                    "a_success": sample_a,
+                    "b_success": sample_b,
+                    "a_trials": trials,
+                    "b_trials": trials,
+                    "confidence_level": 1 - alpha,
+                },
+                kwargs,
+            )
             conf_interval: types.ManyIntervalType = BinomTwoSampleCI.confidence_interval(**binom_kwargs)
             power: np.ndarray = helper_dir.__helper_calc_empirical_power(conf_interval)
             if as_numeric:

--- a/ambrosia/tools/pvalue_tools.py
+++ b/ambrosia/tools/pvalue_tools.py
@@ -151,11 +151,12 @@ def choose_from_bounds(
     Choose left and right bounds according to alternative
     """
     cond_many: bool = isinstance(left_ci, Iterable)
-    amount: int = len(left_ci) if cond_many else 1
+    # np.full preserves the bounds shape for arrays of any dimension,
+    # e.g. the (amount, grid size) matrices used by the binary power tables.
     if alternative == "greater":
-        right_ci = np.ones(amount) * right_bound if cond_many else right_bound
+        right_ci = np.full(np.shape(right_ci), right_bound, dtype=float) if cond_many else right_bound
     if alternative == "less":
-        left_ci = np.ones(amount) * left_bound if cond_many else left_bound
+        left_ci = np.full(np.shape(left_ci), left_bound, dtype=float) if cond_many else left_bound
     return left_ci, right_ci
 
 

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -353,7 +353,7 @@ def test_prior_designing_binary():
     n_incorrect: int = design_binary_size(
         0.99,
         effects=[1.01],
-        methdo="binary",
+        method="binary",
         interval_type="bayes_beta",
         n_success_conjugate=1,
         n_failure_conjugate=1000002,
@@ -362,10 +362,22 @@ def test_prior_designing_binary():
 
     # Test effect
     effect_correct = design_binary_effect(
-        0.1, sizes=[5000], interval_type="bayes_beta", n_success_conjugate=1, n_failure_conjugate=10, as_numeric=True
+        0.1,
+        sizes=[5000],
+        method="binary",
+        interval_type="bayes_beta",
+        n_success_conjugate=1,
+        n_failure_conjugate=10,
+        as_numeric=True,
     ).iloc[0, 0]
     effect_incorrect = design_binary_effect(
-        0.9, sizes=[5000], interval_type="bayes_beta", n_success_conjugate=1, n_failure_conjugate=10, as_numeric=True
+        0.9,
+        sizes=[5000],
+        method="binary",
+        interval_type="bayes_beta",
+        n_success_conjugate=1,
+        n_failure_conjugate=10,
+        as_numeric=True,
     ).iloc[0, 0]
     assert effect_correct > effect_incorrect
 
@@ -374,6 +386,7 @@ def test_prior_designing_binary():
         0.1,
         sizes=5000,
         effects=1.05,
+        method="binary",
         interval_type="bayes_beta",
         n_success_conjugate=1,
         n_failure_conjugate=10,
@@ -383,6 +396,7 @@ def test_prior_designing_binary():
         0.9,
         sizes=5000,
         effects=1.05,
+        method="binary",
         interval_type="bayes_beta",
         n_success_conjugate=1,
         n_failure_conjugate=10,
@@ -390,3 +404,26 @@ def test_prior_designing_binary():
     ).iloc[0, 0]
 
     assert power_correct < power_incorrect
+
+
+@pytest.mark.unit
+def test_binary_design_priors_affect_results():
+    """
+    Regression test for the kwargs threading fix: with ``interval_type="bayes_beta"``
+    the conjugate prior parameters must reach the interval computation, so designs
+    that differ only in the prior must produce different results (previously the
+    extra keyword arguments raised a ``TypeError`` in the design table builders).
+    """
+    common = {"effects": [1.2], "method": "binary", "interval_type": "bayes_beta"}
+    size_weak_prior = design_binary_size(0.05, n_success_conjugate=1, n_failure_conjugate=10, **common).iloc[0, 0]
+    size_strong_prior = design_binary_size(0.05, n_success_conjugate=500, n_failure_conjugate=500, **common).iloc[0, 0]
+    assert size_weak_prior != size_strong_prior
+
+    power_kwargs = {"sizes": 3000, "effects": 1.05, "method": "binary", "as_numeric": True}
+    power_weak = design_binary_power(
+        0.1, interval_type="bayes_beta", n_success_conjugate=1, n_failure_conjugate=10, **power_kwargs
+    ).iloc[0, 0]
+    power_strong = design_binary_power(
+        0.1, interval_type="bayes_beta", n_success_conjugate=2000, n_failure_conjugate=2000, **power_kwargs
+    ).iloc[0, 0]
+    assert power_weak != power_strong

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -7,7 +7,15 @@ import pytest
 import yaml
 from pytest_lazy_fixtures import lf
 
-from ambrosia.designer import Designer, design, design_binary, load_from_config
+from ambrosia.designer import (
+    Designer,
+    design,
+    design_binary,
+    design_binary_effect,
+    design_binary_power,
+    design_binary_size,
+    load_from_config,
+)
 
 store_path: str = "tests/configs/dumped_designer.yaml"
 
@@ -328,3 +336,57 @@ def test_groups_ratio_parameter(to_design, method, effects, sizes, designer_ltv)
             )
         results_list.append((1.0 + groups_ratio) * res)
     assert np.all(results_list[0].values < results_list[1].values < results_list[2].values)
+
+
+@pytest.mark.smoke
+def test_prior_designing_binary():
+    # Correct prior
+    n_correct: int = design_binary_size(
+        0.01,
+        effects=[1.01],
+        method="binary",
+        interval_type="bayes_beta",
+        n_success_conjugate=1,
+        n_failure_conjugate=1000002,
+    ).iloc[0, 0]
+    # Incorrect prior
+    n_incorrect: int = design_binary_size(
+        0.99,
+        effects=[1.01],
+        methdo="binary",
+        interval_type="bayes_beta",
+        n_success_conjugate=1,
+        n_failure_conjugate=1000002,
+    ).iloc[0, 0]
+    assert n_correct > n_incorrect
+
+    # Test effect
+    effect_correct = design_binary_effect(
+        0.1, sizes=[5000], interval_type="bayes_beta", n_success_conjugate=1, n_failure_conjugate=10, as_numeric=True
+    ).iloc[0, 0]
+    effect_incorrect = design_binary_effect(
+        0.9, sizes=[5000], interval_type="bayes_beta", n_success_conjugate=1, n_failure_conjugate=10, as_numeric=True
+    ).iloc[0, 0]
+    assert effect_correct > effect_incorrect
+
+    # Test power
+    power_correct = design_binary_power(
+        0.1,
+        sizes=5000,
+        effects=1.05,
+        interval_type="bayes_beta",
+        n_success_conjugate=1,
+        n_failure_conjugate=10,
+        as_numeric=True,
+    ).iloc[0, 0]
+    power_incorrect = design_binary_power(
+        0.9,
+        sizes=5000,
+        effects=1.05,
+        interval_type="bayes_beta",
+        n_success_conjugate=1,
+        n_failure_conjugate=10,
+        as_numeric=True,
+    ).iloc[0, 0]
+
+    assert power_correct < power_incorrect

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from pytest_lazy_fixtures import lf
 
+import ambrosia.tools.bin_intervals as bin_pkg
 from ambrosia.designer import (
     Designer,
     design,
@@ -340,6 +341,7 @@ def test_groups_ratio_parameter(to_design, method, effects, sizes, designer_ltv)
 
 @pytest.mark.smoke
 def test_prior_designing_binary():
+    np.random.seed(33)
     # Correct prior
     n_correct: int = design_binary_size(
         0.01,
@@ -414,6 +416,7 @@ def test_binary_design_priors_affect_results():
     that differ only in the prior must produce different results (previously the
     extra keyword arguments raised a ``TypeError`` in the design table builders).
     """
+    np.random.seed(33)
     common = {"effects": [1.2], "method": "binary", "interval_type": "bayes_beta"}
     size_weak_prior = design_binary_size(0.05, n_success_conjugate=1, n_failure_conjugate=10, **common).iloc[0, 0]
     size_strong_prior = design_binary_size(0.05, n_success_conjugate=500, n_failure_conjugate=500, **common).iloc[0, 0]
@@ -427,3 +430,61 @@ def test_binary_design_priors_affect_results():
         0.1, interval_type="bayes_beta", n_success_conjugate=2000, n_failure_conjugate=2000, **power_kwargs
     ).iloc[0, 0]
     assert power_weak != power_strong
+
+
+@pytest.mark.unit
+def test_binary_design_priors_via_designer_class():
+    """
+    The Designer class route must also deliver the prior parameters to the
+    interval computation.
+    """
+    np.random.seed(33)
+    frame = pd.DataFrame({"conversion": np.array([0, 1] * 50)})
+    designer = Designer(dataframe=frame, metrics="conversion", effects=[1.2])
+    size_weak = designer.run(
+        "size", method="binary", interval_type="bayes_beta", n_success_conjugate=1, n_failure_conjugate=10
+    ).iloc[0, 0]
+    size_strong = designer.run(
+        "size", method="binary", interval_type="bayes_beta", n_success_conjugate=500, n_failure_conjugate=500
+    ).iloc[0, 0]
+    assert size_weak != size_strong
+
+
+@pytest.mark.unit
+def test_derived_ci_arguments_cannot_be_overridden():
+    """
+    Keyword arguments colliding with internally derived confidence interval
+    arguments must raise instead of silently overriding them.
+    """
+    with pytest.raises(ValueError, match="derived from the design parameters"):
+        bin_pkg.get_table_power_on_size_and_delta(
+            p_a=0.3,
+            sample_sizes=[500],
+            first_errors=[0.05],
+            delta_relative_values=[1.1],
+            confidence_level=0.9,
+        )
+    with pytest.raises(ValueError, match="derived from the design parameters"):
+        design_binary_size(0.05, effects=[1.2], method="binary", a_trials=100)
+
+
+@pytest.mark.unit
+def test_one_sided_alternative_binary_power_table():
+    """
+    One-sided alternatives flow into the binary power table without shape
+    errors (regression for the 2-D confidence bounds handling) and a one-sided
+    test is at least as powerful as the two-sided one.
+    """
+    np.random.seed(33)
+    table_kwargs = {
+        "p_a": 0.3,
+        "sample_sizes": [1000],
+        "first_errors": [0.05],
+        "delta_relative_values": [1.15],
+        "amount": 2000,
+        "as_numeric": True,
+    }
+    power_two_sided = bin_pkg.get_table_power_on_size_and_delta(**table_kwargs).iloc[0, 0]
+    power_greater = bin_pkg.get_table_power_on_size_and_delta(alternative="greater", **table_kwargs).iloc[0, 0]
+    assert 0.0 <= power_greater <= 1.0
+    assert power_greater >= power_two_sided


### PR DESCRIPTION
## What

Ports and extends the fix from #45 (thanks @VictorFromChoback / Artem Vasin — authorship preserved via cherry-pick).

**The bug:** with `interval_type="bayes_beta"` the conjugate prior parameters (`n_success_conjugate`, `n_failure_conjugate`) never reached `BinomTwoSampleCI.confidence_interval` — on current `main` every binary design call with priors fails with `TypeError: unexpected keyword argument`. The fix threads `**kwargs` through the design table builders and binary-search helpers (size, effect and power, both the standalone functions and the `Designer` class route).

## Hardening on top of the original fix (review findings)

- `merge_ci_kwargs` raises a clear `ValueError` when user kwargs collide with internally derived CI arguments (previously `**kwargs` would silently override e.g. the alpha-derived `confidence_level`, mislabeling results).
- `choose_from_bounds` now preserves the bounds shape (`np.full`), fixing `alternative="greater"/"less"` for the 2-D simulation matrices in the binary power table (latent shape bug exposed by the kwargs threading).
- Fixed a `methdo` typo in the ported test and routed all its calls through the binary path (they silently fell back to the theory path where priors are unused).

## Tests

- `test_prior_designing_binary` (from #45, fixed and seeded)
- `test_binary_design_priors_affect_results` — same `p_a`, different priors → different size/power (regression for the threading)
- `test_binary_design_priors_via_designer_class` — the `Designer.run` route
- `test_derived_ci_arguments_cannot_be_overridden`, `test_one_sided_alternative_binary_power_table`

Full suite: 1756 passed (baseline 1751 + 5 new), 48 pre-existing Spark-environment errors unchanged.

Closes #45.
