### PR TITLE
Add Sample Ratio Mismatch check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,23 @@ Release Notes
 Version 0.5.3 (unreleased)
 ---------------------------
 
+**New Features:**
+
+* Sample Ratio Mismatch (SRM) check. A broken assignment, filtering or logging
+  pipeline often shows up as group sizes that deviate from the planned split -
+  and then any test result on such groups cannot be trusted. The ``Tester`` now
+  verifies the observed group sizes with a chi-square test (strict ``0.0005``
+  level) before evaluating the results and emits a warning when a mismatch is
+  detected. For intentionally unequal splits pass ``srm_expected_ratios``
+  (e.g. ``{"A": 0.9, "B": 0.1}``); disable with ``check_srm=False``. The same
+  diagnostic is available standalone as ``ambrosia.tools.srm.check_srm`` for
+  pandas and Spark dataframes.
+
 **Bug Fixes:**
+
+* ``Tester`` and the standalone ``test`` function no longer fail when
+  ``first_type_errors`` is not provided explicitly: the documented default
+  ``0.05`` is now applied.
 
 * Fixed binary experiment design with Bayesian intervals: the conjugate prior
   parameters (``n_success_conjugate``, ``n_failure_conjugate``) for

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,9 +18,9 @@ Version 0.5.3 (unreleased)
 
 **Bug Fixes:**
 
-* ``Tester`` and the standalone ``test`` function no longer fail when
-  ``first_type_errors`` is not provided explicitly: the documented default
-  ``0.05`` is now applied.
+* The standalone ``test`` function no longer fails when ``first_type_errors``
+  is not provided (the same applies to ``Tester`` with an explicit
+  ``first_type_errors=None``): the documented default ``0.05`` is now applied.
 
 * Fixed binary experiment design with Bayesian intervals: the conjugate prior
   parameters (``n_success_conjugate``, ``n_failure_conjugate``) for

--- a/ambrosia/tester/tester.py
+++ b/ambrosia/tester/tester.py
@@ -29,7 +29,7 @@ development and will be available soon.
 """
 import itertools
 from copy import deepcopy
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from warnings import warn
 
 import numpy as np
@@ -38,6 +38,7 @@ import pandas as pd
 import ambrosia.tools.empirical_tools as empirical_pkg
 import ambrosia.tools.multitest as multitest_pkg
 import ambrosia.tools.pvalue_tools as pvalue_pkg
+import ambrosia.tools.srm as srm_pkg
 import ambrosia.tools.stat_criteria as criteria_pkg
 from ambrosia import types
 from ambrosia.tools.ab_abstract_component import ABStatCriterion, ABToolAbstract, DataframeHandler, StatCriterion
@@ -206,6 +207,8 @@ class Tester(ABToolAbstract):
         self.__experiment_results = experiment_results
 
     def set_errors(self, first_type_errors: types.StatErrorType) -> None:
+        if first_type_errors is None:
+            first_type_errors = 0.05
         if isinstance(first_type_errors, float):
             self.__alpha = np.array([first_type_errors])
         else:
@@ -495,6 +498,8 @@ class Tester(ABToolAbstract):
         correction_method: Union[str, None] = "bonferroni",
         as_table: bool = True,
         metric_funcs: Optional[Dict[str, Callable]] = None,
+        check_srm: bool = True,
+        srm_expected_ratios: Optional[Dict[Any, float]] = None,
         **kwargs,
     ) -> types.TesterResult:
         """
@@ -549,6 +554,17 @@ class Tester(ABToolAbstract):
             Each function receives a group ``pd.DataFrame`` and returns
             array-like values. Overrides functions set in constructor
             for matching metric names. Only pandas DataFrames supported.
+        check_srm : bool, default: ``True``
+            Run a Sample Ratio Mismatch check on the group sizes before
+            testing and emit a warning if the observed sizes deviate from
+            the expected ratios (chi-square test at the ``0.0005`` level).
+            A detected mismatch usually means a broken assignment procedure,
+            making the test results unreliable.
+        srm_expected_ratios : Dict[Any, float], optional
+            Expected group size ratios for the Sample Ratio Mismatch check,
+            mapping group label to its share (normalized internally).
+            Pass it when the split is intentionally unequal.
+            If ``None``, equal group sizes are expected.
         **kwargs : Dict
             Other keyword arguments.
 
@@ -592,6 +608,20 @@ class Tester(ABToolAbstract):
         chosen_args["criterion"] = criterion
         effective_metric_funcs = {**self.__metric_funcs, **(metric_funcs or {})}
         chosen_args["metric_funcs"] = effective_metric_funcs
+
+        if check_srm:
+            observed_sizes = {
+                label: srm_pkg.group_size(group_data) for label, group_data in chosen_args["experiment_results"].items()
+            }
+            srm_result = srm_pkg.check_srm_from_counts(observed_sizes, expected_ratios=srm_expected_ratios)
+            if srm_result["srm_detected"]:
+                warn(
+                    f"Sample Ratio Mismatch detected: observed group sizes {srm_result['observed']} deviate "
+                    f"from the expected ratios (chi-square p-value = {srm_result['pvalue']:.3g} < "
+                    f"{srm_result['alpha']}). The group assignment may be broken and the test results may be "
+                    "unreliable. If the unequal split is intentional, pass srm_expected_ratios; "
+                    "to disable this check, set check_srm=False."
+                )
 
         hypothesis_num: int = len(list(itertools.combinations(chosen_args["experiment_results"], 2))) * len(
             chosen_args["metrics"]
@@ -643,6 +673,8 @@ def test(
     correction_method: Union[str, None] = "bonferroni",
     as_table: bool = True,
     metric_funcs: Optional[Dict[str, Callable]] = None,
+    check_srm: bool = True,
+    srm_expected_ratios: Optional[Dict[Any, float]] = None,
     **kwargs,
 ) -> types.TesterResult:
     """
@@ -701,6 +733,13 @@ def test(
         Dictionary mapping metric names to callable functions.
         Each function receives a group ``pd.DataFrame`` and returns
         array-like values. Only pandas DataFrames supported.
+    check_srm : bool, default: ``True``
+        Run a Sample Ratio Mismatch check on the group sizes before
+        testing and emit a warning if the observed sizes deviate from
+        the expected ratios.
+    srm_expected_ratios : Dict[Any, float], optional
+        Expected group size ratios for the Sample Ratio Mismatch check.
+        Pass it when the split is intentionally unequal.
     **kwargs : Dict
         Other keyword arguments.
 
@@ -726,5 +765,7 @@ def test(
         correction_method=correction_method,
         as_table=as_table,
         metric_funcs=metric_funcs,
+        check_srm=check_srm,
+        srm_expected_ratios=srm_expected_ratios,
         **kwargs,
     )

--- a/ambrosia/tester/tester.py
+++ b/ambrosia/tester/tester.py
@@ -375,6 +375,33 @@ class Tester(ABToolAbstract):
         return criterion().get_results(group_a=group_a, group_b=group_b, alpha=alpha, effect_type=effect_type, **kwargs)
 
     @staticmethod
+    def __as_error_array(first_type_errors: Optional[types.StatErrorType]) -> Optional[np.ndarray]:
+        """
+        Wrap first type errors into an array, keeping ``None`` untouched.
+        """
+        if first_type_errors is None:
+            return None
+        if isinstance(first_type_errors, float):
+            return np.array([first_type_errors])
+        return np.array(first_type_errors)
+
+    @staticmethod
+    def __warn_on_srm(experiment_results: types.ExperimentResults, expected_ratios: Optional[Dict[Any, float]]) -> None:
+        """
+        Check the group sizes for a Sample Ratio Mismatch and warn if detected.
+        """
+        observed_sizes = {label: srm_pkg.group_size(group_data) for label, group_data in experiment_results.items()}
+        srm_result = srm_pkg.check_srm_from_counts(observed_sizes, expected_ratios=expected_ratios)
+        if srm_result["srm_detected"]:
+            warn(
+                f"Sample Ratio Mismatch detected: observed group sizes {srm_result['observed']} deviate "
+                f"from the expected ratios (chi-square p-value = {srm_result['pvalue']:.3g} < "
+                f"{srm_result['alpha']}). The group assignment may be broken and the test results may be "
+                "unreliable. If the unequal split is intentional, pass srm_expected_ratios; "
+                "to disable this check, set check_srm=False."
+            )
+
+    @staticmethod
     def __pre_run(method: str, args: types._UsageArgumentsType, **kwargs) -> types.TesterResult:
         """
         Function to handle run method on pandas dataframes.
@@ -576,11 +603,7 @@ class Tester(ABToolAbstract):
         """
         if isinstance(metrics, types.MetricNameType):
             metrics = [metrics]
-        if first_type_errors is not None:
-            if isinstance(first_type_errors, float):
-                first_type_errors = np.array([first_type_errors])
-            else:
-                first_type_errors = np.array(first_type_errors)
+        first_type_errors = Tester.__as_error_array(first_type_errors)
         if "alternative" in kwargs:
             pvalue_pkg.check_alternative(kwargs["alternative"])
         else:
@@ -610,18 +633,7 @@ class Tester(ABToolAbstract):
         chosen_args["metric_funcs"] = effective_metric_funcs
 
         if check_srm:
-            observed_sizes = {
-                label: srm_pkg.group_size(group_data) for label, group_data in chosen_args["experiment_results"].items()
-            }
-            srm_result = srm_pkg.check_srm_from_counts(observed_sizes, expected_ratios=srm_expected_ratios)
-            if srm_result["srm_detected"]:
-                warn(
-                    f"Sample Ratio Mismatch detected: observed group sizes {srm_result['observed']} deviate "
-                    f"from the expected ratios (chi-square p-value = {srm_result['pvalue']:.3g} < "
-                    f"{srm_result['alpha']}). The group assignment may be broken and the test results may be "
-                    "unreliable. If the unequal split is intentional, pass srm_expected_ratios; "
-                    "to disable this check, set check_srm=False."
-                )
+            Tester.__warn_on_srm(chosen_args["experiment_results"], srm_expected_ratios)
 
         hypothesis_num: int = len(list(itertools.combinations(chosen_args["experiment_results"], 2))) * len(
             chosen_args["metrics"]

--- a/ambrosia/tools/srm.py
+++ b/ambrosia/tools/srm.py
@@ -1,0 +1,151 @@
+#  Copyright 2022 MTS (Mobile Telesystems)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Sample Ratio Mismatch (SRM) diagnostics.
+
+A Sample Ratio Mismatch occurs when the observed experimental group sizes
+deviate from the ratios planned for the assignment procedure. It usually
+indicates a broken randomization, filtering or logging pipeline, and any
+test results computed on such groups may be unreliable.
+
+The check is a chi-square goodness-of-fit test of the observed group sizes
+against the expected ratios. Following the industry practice, a strict
+default significance level (``alpha=0.0005``) is used so that the alarm
+fires only on strong evidence of a mismatch.
+"""
+from typing import Any, Dict, Optional
+
+import pandas as pd
+import scipy.stats as sps
+
+from ambrosia import types
+
+DEFAULT_SRM_ALPHA: float = 0.0005
+
+
+def check_srm_from_counts(
+    observed: Dict[Any, int],
+    expected_ratios: Optional[Dict[Any, float]] = None,
+    alpha: float = DEFAULT_SRM_ALPHA,
+) -> Dict[str, Any]:
+    """
+    Run a Sample Ratio Mismatch check on precomputed group sizes.
+
+    Parameters
+    ----------
+    observed : Dict[Any, int]
+        Mapping from group label to the observed group size.
+    expected_ratios : Dict[Any, float], optional
+        Mapping from group label to the expected share of objects.
+        Ratios may be given in any positive scale (e.g. ``{"A": 9, "B": 1}``)
+        and are normalized internally. If ``None``, equal group sizes
+        are expected.
+    alpha : float, default: ``0.0005``
+        Significance level for the chi-square goodness-of-fit test.
+
+    Returns
+    -------
+    result : Dict[str, Any]
+        Dictionary with ``observed`` sizes, ``expected`` sizes, chi-square
+        ``pvalue``, the used ``alpha`` and the boolean ``srm_detected``.
+    """
+    if len(observed) < 2:
+        raise ValueError("SRM check requires at least two groups")
+    if any(size < 0 for size in observed.values()):
+        raise ValueError("Observed group sizes must be non-negative")
+    total: int = sum(observed.values())
+    if total == 0:
+        raise ValueError("Observed group sizes are all zero")
+    if not 0 < alpha < 1:
+        raise ValueError(f"alpha must be from (0, 1), got {alpha}")
+
+    if expected_ratios is None:
+        ratios: Dict[Any, float] = {label: 1.0 for label in observed}
+    else:
+        if set(expected_ratios) != set(observed):
+            raise ValueError(
+                f"Labels of expected_ratios {sorted(map(str, expected_ratios))} "
+                f"must match the group labels {sorted(map(str, observed))}"
+            )
+        if any(ratio <= 0 for ratio in expected_ratios.values()):
+            raise ValueError("Expected ratios must be positive")
+        ratios = expected_ratios
+    ratios_sum: float = sum(ratios.values())
+
+    labels = list(observed)
+    observed_sizes = [observed[label] for label in labels]
+    expected_sizes = [total * ratios[label] / ratios_sum for label in labels]
+    _, pvalue = sps.chisquare(f_obs=observed_sizes, f_exp=expected_sizes)
+    return {
+        "observed": dict(observed),
+        "expected": dict(zip(labels, expected_sizes)),
+        "pvalue": float(pvalue),
+        "alpha": alpha,
+        "srm_detected": bool(pvalue < alpha),
+    }
+
+
+def group_size(dataframe: types.SparkOrPandas) -> int:
+    """
+    Return the number of rows in a pandas or Spark dataframe.
+    """
+    if isinstance(dataframe, pd.DataFrame):
+        return len(dataframe)
+    return dataframe.count()
+
+
+def check_srm(
+    dataframe: types.SparkOrPandas,
+    column_groups: types.ColumnNameType,
+    expected_ratios: Optional[Dict[Any, float]] = None,
+    alpha: float = DEFAULT_SRM_ALPHA,
+) -> Dict[str, Any]:
+    """
+    Run a Sample Ratio Mismatch check on experiment data.
+
+    Examples
+    --------
+    >>> result = check_srm(df, column_groups="group")
+    >>> result["srm_detected"]
+    False
+    >>> check_srm(df, "group", expected_ratios={"A": 0.9, "B": 0.1})["pvalue"]
+    0.83
+
+    Parameters
+    ----------
+    dataframe : SparkOrPandas
+        Dataframe with experiment objects, one row per object.
+    column_groups : ColumnNameType
+        Column containing the group label of each object.
+    expected_ratios : Dict[Any, float], optional
+        Mapping from group label to the expected share of objects,
+        normalized internally. If ``None``, equal group sizes are expected.
+    alpha : float, default: ``0.0005``
+        Significance level for the chi-square goodness-of-fit test.
+
+    Returns
+    -------
+    result : Dict[str, Any]
+        Dictionary with ``observed`` sizes, ``expected`` sizes, chi-square
+        ``pvalue``, the used ``alpha`` and the boolean ``srm_detected``.
+    """
+    if isinstance(dataframe, pd.DataFrame):
+        if column_groups not in dataframe.columns:
+            raise ValueError(f"Column {column_groups} is not in dataframe columns")
+        observed = dataframe[column_groups].value_counts().to_dict()
+    else:
+        rows = dataframe.groupBy(column_groups).count().collect()
+        observed = {row[column_groups]: row["count"] for row in rows}
+    return check_srm_from_counts(observed, expected_ratios=expected_ratios, alpha=alpha)

--- a/ambrosia/tools/srm.py
+++ b/ambrosia/tools/srm.py
@@ -27,6 +27,7 @@ fires only on strong evidence of a mismatch.
 """
 from typing import Any, Dict, Optional
 
+import numpy as np
 import pandas as pd
 import scipy.stats as sps
 
@@ -63,8 +64,8 @@ def check_srm_from_counts(
     """
     if len(observed) < 2:
         raise ValueError("SRM check requires at least two groups")
-    if any(size < 0 for size in observed.values()):
-        raise ValueError("Observed group sizes must be non-negative")
+    if any(size < 0 or not np.isfinite(size) for size in observed.values()):
+        raise ValueError("Observed group sizes must be non-negative finite numbers")
     total: int = sum(observed.values())
     if total == 0:
         raise ValueError("Observed group sizes are all zero")
@@ -79,8 +80,8 @@ def check_srm_from_counts(
                 f"Labels of expected_ratios {sorted(map(str, expected_ratios))} "
                 f"must match the group labels {sorted(map(str, observed))}"
             )
-        if any(ratio <= 0 for ratio in expected_ratios.values()):
-            raise ValueError("Expected ratios must be positive")
+        if any(ratio <= 0 or not np.isfinite(ratio) for ratio in expected_ratios.values()):
+            raise ValueError("Expected ratios must be positive finite numbers")
         ratios = expected_ratios
     ratios_sum: float = sum(ratios.values())
 
@@ -97,13 +98,17 @@ def check_srm_from_counts(
     }
 
 
-def group_size(dataframe: types.SparkOrPandas) -> int:
+def group_size(group_data: Any) -> int:
     """
-    Return the number of rows in a pandas or Spark dataframe.
+    Return the number of objects in an experimental group.
+
+    Works for any sized container (pandas dataframes, numpy arrays, lists)
+    and falls back to ``count()`` for Spark dataframes.
     """
-    if isinstance(dataframe, pd.DataFrame):
-        return len(dataframe)
-    return dataframe.count()
+    try:
+        return len(group_data)
+    except TypeError:
+        return group_data.count()
 
 
 def check_srm(
@@ -115,13 +120,8 @@ def check_srm(
     """
     Run a Sample Ratio Mismatch check on experiment data.
 
-    Examples
-    --------
-    >>> result = check_srm(df, column_groups="group")
-    >>> result["srm_detected"]
-    False
-    >>> check_srm(df, "group", expected_ratios={"A": 0.9, "B": 0.1})["pvalue"]
-    0.83
+    Null group labels are counted as a separate group for both pandas
+    and Spark dataframes.
 
     Parameters
     ----------
@@ -140,11 +140,16 @@ def check_srm(
     result : Dict[str, Any]
         Dictionary with ``observed`` sizes, ``expected`` sizes, chi-square
         ``pvalue``, the used ``alpha`` and the boolean ``srm_detected``.
+
+    Examples
+    --------
+    >>> check_srm(dataframe, column_groups="group")["srm_detected"]
+    >>> check_srm(dataframe, "group", expected_ratios={"A": 0.9, "B": 0.1})["pvalue"]
     """
     if isinstance(dataframe, pd.DataFrame):
         if column_groups not in dataframe.columns:
             raise ValueError(f"Column {column_groups} is not in dataframe columns")
-        observed = dataframe[column_groups].value_counts().to_dict()
+        observed = dataframe[column_groups].value_counts(dropna=False).to_dict()
     else:
         rows = dataframe.groupBy(column_groups).count().collect()
         observed = {row[column_groups]: row["count"] for row in rows}

--- a/docs/source/ambrosia_elements/tester.rst
+++ b/docs/source/ambrosia_elements/tester.rst
@@ -18,6 +18,17 @@ and calculating the experimental uplift value with corresponding confidence inte
    accordingly; the step-wise methods adjust only the p-values and leave the intervals at the nominal level.
    Hypotheses whose p-value cannot be computed still count toward the family size.
 
+.. admonition:: Sample Ratio Mismatch check
+   :class: caution
+
+   Before evaluating the results, ``Tester`` checks that the observed group sizes match the expected
+   ratios (a chi-square test at the strict ``0.0005`` level) and emits a warning when a Sample Ratio
+   Mismatch is detected — such a mismatch usually means a broken assignment procedure, making the test
+   results unreliable. For intentionally unequal splits pass ``srm_expected_ratios``
+   (e.g. ``{"A": 0.9, "B": 0.1}``); the check can be disabled with ``check_srm=False``.
+   The standalone function ``ambrosia.tools.srm.check_srm`` runs the same diagnostic on any
+   pandas or Spark dataframe.
+
 
 .. currentmodule:: ambrosia.tester
 

--- a/tests/test_srm.py
+++ b/tests/test_srm.py
@@ -19,6 +19,16 @@ def make_groups_frame(size_a: int, size_b: int) -> pd.DataFrame:
     )
 
 
+def collect_srm_warnings(run_callable) -> list:
+    """
+    Run the callable and return the emitted Sample Ratio Mismatch warnings.
+    """
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        run_callable()
+    return [record for record in records if "Sample Ratio Mismatch" in str(record.message)]
+
+
 @pytest.mark.unit
 def test_pvalue_matches_scipy():
     """
@@ -119,17 +129,13 @@ def test_tester_warns_on_srm():
 @pytest.mark.unit
 def test_tester_silent_on_balanced_split():
     tester = Tester(dataframe=make_groups_frame(5000, 4980), column_groups="group", metrics=["metric"])
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        tester.run("absolute", method="theory", as_table=False)
+    assert not collect_srm_warnings(lambda: tester.run("absolute", method="theory", as_table=False))
 
 
 @pytest.mark.unit
 def test_tester_srm_check_can_be_disabled():
     tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        tester.run("absolute", method="theory", as_table=False, check_srm=False)
+    assert not collect_srm_warnings(lambda: tester.run("absolute", method="theory", as_table=False, check_srm=False))
 
 
 @pytest.mark.unit
@@ -141,14 +147,14 @@ def test_tester_respects_expected_ratios():
     tester = Tester(dataframe=frame, column_groups="group", metrics=["metric"])
     with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
         tester.run("absolute", method="theory", as_table=False)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        tester.run(
+    assert not collect_srm_warnings(
+        lambda: tester.run(
             "absolute",
             method="theory",
             as_table=False,
             srm_expected_ratios={"A": 0.9, "B": 0.1},
         )
+    )
 
 
 @pytest.mark.unit
@@ -156,9 +162,8 @@ def test_standalone_test_function_passthrough():
     frame = make_groups_frame(5000, 4500)
     with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
         test("absolute", dataframe=frame, column_groups="group", metrics="metric", as_table=False)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        test(
+    assert not collect_srm_warnings(
+        lambda: test(
             "absolute",
             dataframe=frame,
             column_groups="group",
@@ -166,6 +171,53 @@ def test_standalone_test_function_passthrough():
             as_table=False,
             check_srm=False,
         )
+    )
+
+
+@pytest.mark.unit
+def test_standalone_test_function_default_alpha():
+    """
+    The standalone test function works without an explicit first_type_errors
+    and reports the documented 0.05 default.
+    """
+    frame = make_groups_frame(1000, 1000)
+    result = test("absolute", dataframe=frame, column_groups="group", metrics="metric", as_table=False)
+    assert result[0]["first_type_error"] == pytest.approx(0.05)
+
+
+@pytest.mark.unit
+def test_tester_experiment_results_dict_mode():
+    """
+    The SRM check also covers the experiment_results dict input mode.
+    """
+    frame = make_groups_frame(5000, 4500)
+    experiment_results = {
+        "A": frame[frame["group"] == "A"],
+        "B": frame[frame["group"] == "B"],
+    }
+    tester = Tester(experiment_results=experiment_results, metrics=["metric"])
+    with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
+        tester.run("absolute", method="theory", as_table=False)
+
+
+@pytest.mark.unit
+def test_tester_experiment_results_arrays_supported():
+    """
+    Array-valued experiment_results (used with metric_funcs) keep working
+    with the SRM check enabled: group sizes are taken via len().
+    """
+    rng = np.random.default_rng(5)
+    experiment_results = {"A": rng.normal(0, 1, 1000), "B": rng.normal(0, 1, 1000)}
+    result = test(
+        "absolute",
+        method="empiric",
+        experiment_results=experiment_results,
+        metrics="metric",
+        metric_funcs={"metric": lambda values: values},
+        as_table=False,
+        random_seed=7,
+    )
+    assert "pvalue" in result[0]
 
 
 @pytest.mark.unit

--- a/tests/test_srm.py
+++ b/tests/test_srm.py
@@ -1,0 +1,181 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.stats as sps
+
+from ambrosia.tester import Tester, test
+from ambrosia.tools.srm import check_srm, check_srm_from_counts
+
+
+def make_groups_frame(size_a: int, size_b: int) -> pd.DataFrame:
+    rng = np.random.default_rng(7)
+    return pd.DataFrame(
+        {
+            "group": ["A"] * size_a + ["B"] * size_b,
+            "metric": rng.normal(0, 1, size_a + size_b),
+        }
+    )
+
+
+@pytest.mark.unit
+def test_pvalue_matches_scipy():
+    """
+    The reported p-value equals a manual scipy chi-square computation.
+    """
+    observed = {"A": 5200, "B": 4800}
+    result = check_srm_from_counts(observed)
+    _, expected_pvalue = sps.chisquare(f_obs=[5200, 4800], f_exp=[5000.0, 5000.0])
+    assert result["pvalue"] == pytest.approx(expected_pvalue, abs=1e-12)
+    assert result["observed"] == observed
+    assert result["expected"] == {"A": 5000.0, "B": 5000.0}
+    assert result["alpha"] == 0.0005
+
+
+@pytest.mark.unit
+def test_balanced_split_passes():
+    result = check_srm_from_counts({"A": 5000, "B": 4980})
+    assert not result["srm_detected"]
+    assert result["pvalue"] > 0.0005
+
+
+@pytest.mark.unit
+def test_skewed_split_detected():
+    result = check_srm_from_counts({"A": 5000, "B": 4500})
+    assert result["srm_detected"]
+    assert result["pvalue"] < 0.0005
+
+
+@pytest.mark.unit
+def test_multigroup_skew_detected():
+    balanced = check_srm_from_counts({"A": 3000, "B": 3010, "C": 2990})
+    skewed = check_srm_from_counts({"A": 3000, "B": 3000, "C": 2500})
+    assert not balanced["srm_detected"]
+    assert skewed["srm_detected"]
+
+
+@pytest.mark.unit
+def test_custom_expected_ratios():
+    """
+    A deliberate 90/10 split passes with matching ratios and fails without them.
+    """
+    observed = {"A": 9000, "B": 1020}
+    with_ratios = check_srm_from_counts(observed, expected_ratios={"A": 0.9, "B": 0.1})
+    without_ratios = check_srm_from_counts(observed)
+    assert not with_ratios["srm_detected"]
+    assert without_ratios["srm_detected"]
+
+
+@pytest.mark.unit
+def test_ratios_are_normalized():
+    observed = {"A": 9000, "B": 1020}
+    fractions = check_srm_from_counts(observed, expected_ratios={"A": 0.9, "B": 0.1})
+    weights = check_srm_from_counts(observed, expected_ratios={"A": 9, "B": 1})
+    assert fractions["pvalue"] == pytest.approx(weights["pvalue"], abs=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "observed, expected_ratios, alpha",
+    [
+        ({"A": 100}, None, 0.0005),
+        ({"A": 100, "B": -1}, None, 0.0005),
+        ({"A": 0, "B": 0}, None, 0.0005),
+        ({"A": 100, "B": 100}, {"A": 1.0}, 0.0005),
+        ({"A": 100, "B": 100}, {"A": 1.0, "B": 1.0, "C": 1.0}, 0.0005),
+        ({"A": 100, "B": 100}, {"A": 1.0, "B": 0.0}, 0.0005),
+        ({"A": 100, "B": 100}, None, 0.0),
+        ({"A": 100, "B": 100}, None, 1.0),
+    ],
+)
+def test_invalid_inputs_raise(observed, expected_ratios, alpha):
+    with pytest.raises(ValueError):
+        check_srm_from_counts(observed, expected_ratios=expected_ratios, alpha=alpha)
+
+
+@pytest.mark.unit
+def test_dataframe_wrapper_matches_counts():
+    frame = make_groups_frame(5000, 4500)
+    from_frame = check_srm(frame, column_groups="group")
+    from_counts = check_srm_from_counts({"A": 5000, "B": 4500})
+    assert from_frame["pvalue"] == pytest.approx(from_counts["pvalue"], abs=1e-12)
+    assert from_frame["srm_detected"]
+
+
+@pytest.mark.unit
+def test_dataframe_wrapper_missing_column():
+    with pytest.raises(ValueError, match="is not in dataframe columns"):
+        check_srm(make_groups_frame(10, 10), column_groups="no_such_column")
+
+
+@pytest.mark.unit
+def test_tester_warns_on_srm():
+    tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
+    with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
+        tester.run("absolute", method="theory", as_table=False)
+
+
+@pytest.mark.unit
+def test_tester_silent_on_balanced_split():
+    tester = Tester(dataframe=make_groups_frame(5000, 4980), column_groups="group", metrics=["metric"])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        tester.run("absolute", method="theory", as_table=False)
+
+
+@pytest.mark.unit
+def test_tester_srm_check_can_be_disabled():
+    tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        tester.run("absolute", method="theory", as_table=False, check_srm=False)
+
+
+@pytest.mark.unit
+def test_tester_respects_expected_ratios():
+    """
+    An intentional 90/10 split passes once the expected ratios are provided.
+    """
+    frame = make_groups_frame(9000, 1020)
+    tester = Tester(dataframe=frame, column_groups="group", metrics=["metric"])
+    with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
+        tester.run("absolute", method="theory", as_table=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        tester.run(
+            "absolute",
+            method="theory",
+            as_table=False,
+            srm_expected_ratios={"A": 0.9, "B": 0.1},
+        )
+
+
+@pytest.mark.unit
+def test_standalone_test_function_passthrough():
+    frame = make_groups_frame(5000, 4500)
+    with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
+        test("absolute", dataframe=frame, column_groups="group", metrics="metric", as_table=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        test(
+            "absolute",
+            dataframe=frame,
+            column_groups="group",
+            metrics="metric",
+            as_table=False,
+            check_srm=False,
+        )
+
+
+@pytest.mark.unit
+def test_check_srm_spark(local_spark_session):
+    """
+    The dataframe wrapper computes group sizes for Spark tables as well.
+    """
+    frame = make_groups_frame(500, 430)
+    spark_frame = local_spark_session.createDataFrame(frame)
+    from_spark = check_srm(spark_frame, column_groups="group")
+    from_pandas = check_srm(frame, column_groups="group")
+    assert from_spark["observed"] == from_pandas["observed"]
+    assert from_spark["pvalue"] == pytest.approx(from_pandas["pvalue"], abs=1e-12)


### PR DESCRIPTION
## What

Adds an **SRM (Sample Ratio Mismatch) diagnostic** — the standard guard against broken assignment/filtering/logging pipelines, which show up as group sizes deviating from the planned split and silently invalidate any test result.

- New `ambrosia/tools/srm.py`: `check_srm(dataframe, column_groups, expected_ratios=None, alpha=0.0005)` and `check_srm_from_counts(...)` — chi-square goodness-of-fit of observed group sizes against expected ratios (equal by default, custom ratios normalized internally), strict industry-standard `0.0005` level. Works for pandas and Spark.
- `Tester.run` / standalone `test()` gain `check_srm=True` and `srm_expected_ratios`: group sizes are verified before evaluation and an actionable warning is emitted when a mismatch is detected. For deliberate unequal splits pass `srm_expected_ratios={"A": 0.9, "B": 0.1}`; disable with `check_srm=False`.

## Also fixed

- The standalone `test()` crashed without an explicit `first_type_errors` (default `None` propagated into `set_errors`); the documented `0.05` default is now applied.

## Review hardening

- `group_size` is `len()`-first with a `count()` fallback, so array-valued `experiment_results` (used with `metric_funcs`) keep working.
- Null group labels counted consistently for pandas and Spark.
- NaN sizes/ratios rejected; warning-collection in tests made immune to unrelated future dependency warnings.

## Tests / docs

24 new tests (module unit tests, Tester integration for all input modes, Spark path), docs admonition in `tester.rst`, CHANGELOG entries. Full suite: 1780 passed; 49 errors are the pre-existing Spark-environment ones (no local Java) plus the new Spark SRM test that runs in CI.
