### PR TITLE
Release polish for 0.5.3: audit findings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,12 @@ Version 0.5.3 (unreleased)
   arguments (e.g. ``confidence_level``) now raise a clear ``ValueError``
   instead of silently overriding the design parameters.
 
+* The standalone ``design_binary_size`` / ``design_binary_effect`` /
+  ``design_binary_power`` functions now honor ``alternative`` for
+  ``method="binary"`` (previously the argument was silently dropped and the
+  design was always two-sided) and warn about the unsupported
+  ``groups_ratio`` instead of silently designing equal groups.
+
 **Dependencies:**
 
 * Allowed pandas 3.x: the requirement is now ``pandas >=1.5.0, <4.0.0``.

--- a/ambrosia/designer/designer.py
+++ b/ambrosia/designer/designer.py
@@ -651,7 +651,11 @@ def design_binary_size(
         )
     elif method == "binary":
         if groups_ratio != 1.0:
-            warn("groups_ratio is not supported for the binary method and is ignored: equal group sizes are designed")
+            warn(
+                "groups_ratio is not supported for the binary method and is ignored: equal group sizes are "
+                "designed (use method='theory' for unequal groups)",
+                stacklevel=2,
+            )
         return bin_pkg.get_table_sample_size_on_effect(
             p_a=prob_a,
             first_errors=first_type_errors,
@@ -740,7 +744,11 @@ def design_binary_effect(
         )
     elif method == "binary":
         if groups_ratio != 1.0:
-            warn("groups_ratio is not supported for the binary method and is ignored: equal group sizes are designed")
+            warn(
+                "groups_ratio is not supported for the binary method and is ignored: equal group sizes are "
+                "designed (use method='theory' for unequal groups)",
+                stacklevel=2,
+            )
         return bin_pkg.get_table_effect_on_sample_size(
             p_a=prob_a,
             sample_sizes=sizes,
@@ -830,7 +838,11 @@ def design_binary_power(
         )
     elif method == "binary":
         if groups_ratio != 1.0:
-            warn("groups_ratio is not supported for the binary method and is ignored: equal group sizes are designed")
+            warn(
+                "groups_ratio is not supported for the binary method and is ignored: equal group sizes are "
+                "designed (use method='theory' for unequal groups)",
+                stacklevel=2,
+            )
         return bin_pkg.get_table_power_on_size_and_delta(
             p_a=prob_a,
             sample_sizes=sizes,

--- a/ambrosia/designer/designer.py
+++ b/ambrosia/designer/designer.py
@@ -29,6 +29,7 @@ in form of both pandas and Spark(with some restrictions) dataframes.
 from __future__ import annotations
 
 from typing import List, Optional
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -649,11 +650,14 @@ def design_binary_size(
             stabilizing_method=stabilizing_method,
         )
     elif method == "binary":
+        if groups_ratio != 1.0:
+            warn("groups_ratio is not supported for the binary method and is ignored: equal group sizes are designed")
         return bin_pkg.get_table_sample_size_on_effect(
             p_a=prob_a,
             first_errors=first_type_errors,
             second_errors=second_type_errors,
             delta_relative_values=effects,
+            alternative=alternative,
             **kwargs,
         )
     else:
@@ -735,12 +739,15 @@ def design_binary_effect(
             stabilizing_method=stabilizing_method,
         )
     elif method == "binary":
+        if groups_ratio != 1.0:
+            warn("groups_ratio is not supported for the binary method and is ignored: equal group sizes are designed")
         return bin_pkg.get_table_effect_on_sample_size(
             p_a=prob_a,
             sample_sizes=sizes,
             first_errors=first_type_errors,
             second_errors=second_type_errors,
             as_numeric=as_numeric,
+            alternative=alternative,
             **kwargs,
         )
     else:
@@ -822,12 +829,15 @@ def design_binary_power(
             stabilizing_method=stabilizing_method,
         )
     elif method == "binary":
+        if groups_ratio != 1.0:
+            warn("groups_ratio is not supported for the binary method and is ignored: equal group sizes are designed")
         return bin_pkg.get_table_power_on_size_and_delta(
             p_a=prob_a,
             sample_sizes=sizes,
             first_errors=first_type_errors,
             delta_relative_values=effects,
             as_numeric=as_numeric,
+            alternative=alternative,
             **kwargs,
         )
     else:

--- a/ambrosia/tester/tester.py
+++ b/ambrosia/tester/tester.py
@@ -586,7 +586,9 @@ class Tester(ABToolAbstract):
             testing and emit a warning if the observed sizes deviate from
             the expected ratios (chi-square test at the ``0.0005`` level).
             A detected mismatch usually means a broken assignment procedure,
-            making the test results unreliable.
+            making the test results unreliable. The check assumes one row
+            per randomization unit (e.g. one user); for Spark data it
+            triggers a count job per group.
         srm_expected_ratios : Dict[Any, float], optional
             Expected group size ratios for the Sample Ratio Mismatch check,
             mapping group label to its share (normalized internally).

--- a/ambrosia/tools/_lib/_bin_ci_aide.py
+++ b/ambrosia/tools/_lib/_bin_ci_aide.py
@@ -12,12 +12,31 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import numpy as np
 import scipy.stats as sps
 
 from ambrosia import types
+
+
+def check_reserved_kwargs(user_kwargs: Dict[str, Any], reserved: Iterable[str]) -> None:
+    """
+    Raise if user keyword arguments collide with arguments derived from
+    the design parameters.
+
+    Parameters
+    ----------
+    user_kwargs : Dict[str, Any]
+        Extra arguments passed by the caller.
+    reserved : Iterable[str]
+        Names of arguments computed from the design parameters.
+    """
+    overlap = set(user_kwargs) & set(reserved)
+    if overlap:
+        raise ValueError(
+            f"Arguments {sorted(overlap)} are derived from the design parameters and cannot be passed directly"
+        )
 
 
 def merge_ci_kwargs(derived_kwargs: Dict[str, Any], user_kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/ambrosia/tools/bin_intervals.py
+++ b/ambrosia/tools/bin_intervals.py
@@ -658,9 +658,7 @@ def iterate_for_delta(
     """
     Helps to find effect for different params.
     """
-    helper_dir.check_reserved_kwargs(
-        kwargs, ["interval_type", "confidence_level", "p_a", "trials", "amount", "power", "epsilon"]
-    )
+    helper_dir.check_reserved_kwargs(kwargs, ["interval_type", "confidence_level", "p_a", "trials", "amount", "power"])
     multiindex = pd.MultiIndex.from_tuples([(trials,) for trials in sample_sizes], names=[GROUP_SIZE_COL_NAME])
     multicols = pd.MultiIndex.from_tuples(
         [(f"({alpha}; {beta})",) for alpha in first_errors for beta in second_errors],

--- a/ambrosia/tools/bin_intervals.py
+++ b/ambrosia/tools/bin_intervals.py
@@ -552,6 +552,7 @@ def iterate_for_sample_size(
     """
     Iterate over params for different sample size
     """
+    helper_dir.check_reserved_kwargs(kwargs, ["interval_type", "confidence_level", "p_a", "p_b", "amount", "power"])
     # values = [(round(a, ROUND_DIGITS), round(b, ROUND_DIGITS)) for a in first_errors for b in second_errors]
     # table: pd.DataFrame = pd.DataFrame(
     #     index=pd.MultiIndex.from_tuples(values, names=[r"$\alpha$", r"$\beta$"]),
@@ -657,6 +658,9 @@ def iterate_for_delta(
     """
     Helps to find effect for different params.
     """
+    helper_dir.check_reserved_kwargs(
+        kwargs, ["interval_type", "confidence_level", "p_a", "trials", "amount", "power", "epsilon"]
+    )
     multiindex = pd.MultiIndex.from_tuples([(trials,) for trials in sample_sizes], names=[GROUP_SIZE_COL_NAME])
     multicols = pd.MultiIndex.from_tuples(
         [(f"({alpha}; {beta})",) for alpha in first_errors for beta in second_errors],

--- a/ambrosia/tools/srm.py
+++ b/ambrosia/tools/srm.py
@@ -24,6 +24,10 @@ The check is a chi-square goodness-of-fit test of the observed group sizes
 against the expected ratios. Following the industry practice, a strict
 default significance level (``alpha=0.0005``) is used so that the alarm
 fires only on strong evidence of a mismatch.
+
+The dataframe-based check assumes one row per randomization unit (e.g. one
+user). For event- or session-level data aggregate to units first, or pass
+the unit counts directly to ``check_srm_from_counts``.
 """
 from typing import Any, Dict, Optional
 
@@ -120,8 +124,11 @@ def check_srm(
     """
     Run a Sample Ratio Mismatch check on experiment data.
 
+    The dataframe must contain one row per randomization unit (e.g. one
+    user); on event- or session-level data the chi-square test is invalid.
     Null group labels are counted as a separate group for both pandas
-    and Spark dataframes.
+    and Spark dataframes. For Spark dataframes the check triggers a count
+    job over the table.
 
     Parameters
     ----------

--- a/docs/source/ambrosia_elements/tester.rst
+++ b/docs/source/ambrosia_elements/tester.rst
@@ -24,8 +24,10 @@ and calculating the experimental uplift value with corresponding confidence inte
    Before evaluating the results, ``Tester`` checks that the observed group sizes match the expected
    ratios (a chi-square test at the strict ``0.0005`` level) and emits a warning when a Sample Ratio
    Mismatch is detected — such a mismatch usually means a broken assignment procedure, making the test
-   results unreliable. For intentionally unequal splits pass ``srm_expected_ratios``
-   (e.g. ``{"A": 0.9, "B": 0.1}``); the check can be disabled with ``check_srm=False``.
+   results unreliable. The check assumes one row per randomization unit (e.g. one user): on event- or
+   session-level data aggregate to units first or disable the check. For intentionally unequal splits
+   pass ``srm_expected_ratios`` (e.g. ``{"A": 0.9, "B": 0.1}``); the check can be disabled with
+   ``check_srm=False`` (for Spark data it costs one count job per group).
    The standalone function ``ambrosia.tools.srm.check_srm`` runs the same diagnostic on any
    pandas or Spark dataframe.
 

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -466,6 +466,43 @@ def test_derived_ci_arguments_cannot_be_overridden():
         )
     with pytest.raises(ValueError, match="derived from the design parameters"):
         design_binary_size(0.05, effects=[1.2], method="binary", a_trials=100)
+    with pytest.raises(ValueError, match="derived from the design parameters"):
+        design_binary_size(0.05, effects=[1.2], method="binary", confidence_level=0.9)
+    with pytest.raises(ValueError, match="derived from the design parameters"):
+        design_binary_effect(0.1, sizes=[500], method="binary", confidence_level=0.9)
+
+
+@pytest.mark.unit
+def test_binary_standalone_one_sided_alternative():
+    """
+    The standalone design_binary_* functions honor ``alternative`` for
+    ``method="binary"``: a one-sided test is more powerful, hence requires
+    a smaller sample size (previously the argument was silently dropped).
+    """
+    np.random.seed(33)
+    power_kwargs = {"sizes": 1500, "effects": 1.2, "method": "binary", "as_numeric": True}
+    power_two_sided = design_binary_power(0.3, **power_kwargs).iloc[0, 0]
+    power_greater = design_binary_power(0.3, alternative="greater", **power_kwargs).iloc[0, 0]
+    assert power_greater > power_two_sided
+
+    size_two_sided = design_binary_size(0.05, effects=[1.5], method="binary").iloc[0, 0]
+    size_greater = design_binary_size(0.05, effects=[1.5], method="binary", alternative="greater").iloc[0, 0]
+    assert size_greater < size_two_sided
+
+
+@pytest.mark.unit
+def test_binary_groups_ratio_warns():
+    """
+    Unequal group ratios are not implemented for the binary design method:
+    passing one emits a warning instead of being silently ignored.
+    """
+    np.random.seed(33)
+    with pytest.warns(UserWarning, match="groups_ratio is not supported"):
+        design_binary_size(0.05, effects=[1.5], method="binary", groups_ratio=2.0)
+    with pytest.warns(UserWarning, match="groups_ratio is not supported"):
+        design_binary_effect(0.1, sizes=[1000], method="binary", groups_ratio=2.0)
+    with pytest.warns(UserWarning, match="groups_ratio is not supported"):
+        design_binary_power(0.1, sizes=1000, effects=1.1, method="binary", groups_ratio=2.0)
 
 
 @pytest.mark.unit

--- a/tests/test_srm.py
+++ b/tests/test_srm.py
@@ -66,6 +66,21 @@ def test_multigroup_skew_detected():
 
 
 @pytest.mark.unit
+def test_alpha_threshold_band():
+    """
+    A split with a p-value between the strict default alpha and 0.05 is NOT
+    flagged by default, but is flagged at a looser alpha: guards the actual
+    detection threshold rather than a hardcoded 0.05.
+    """
+    observed = {"A": 5110, "B": 4890}
+    default_result = check_srm_from_counts(observed)
+    loose_result = check_srm_from_counts(observed, alpha=0.05)
+    assert 0.0005 < default_result["pvalue"] < 0.05
+    assert not default_result["srm_detected"]
+    assert loose_result["srm_detected"]
+
+
+@pytest.mark.unit
 def test_custom_expected_ratios():
     """
     A deliberate 90/10 split passes with matching ratios and fails without them.


### PR DESCRIPTION
Pre-release audit follow-ups for 0.5.3:

- **One-sided binary design through the standalone wrappers**: `design_binary_size/effect/power` now pass `alternative` into the binary path (previously silently dropped → always two-sided, contradicting the changelog); `groups_ratio` with `method="binary"` now emits an explicit warning instead of silently designing equal groups (kept as a warning, not an error, to preserve the long-standing `design_binary` dispatcher contract).
- **Consistent collision errors**: `iterate_for_sample_size` / `iterate_for_delta` validate user kwargs against derived arguments, so e.g. `confidence_level=...` raises the documented `ValueError` on all three design paths (previously an opaque private-helper `TypeError` on size/effect).
- **SRM hardening**: band test pinning the 0.0005 threshold (kills the `pvalue < 0.05` mutation); documented assumptions (one row per randomization unit; Spark count-job cost) in docstrings, `tester.rst` and the run() docs.

Full suite: 1783 passed / 0 failed (+3 tests), 49 pre-existing Spark-env errors.
