### PR TITLE
Make the SRM check opt-in

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Release Notes
 =============
 
+Version 0.5.4 (unreleased)
+---------------------------
+
+**Changes:**
+
+* The Sample Ratio Mismatch check in ``Tester`` is now opt-in: ``run`` no
+  longer verifies the group sizes by default, so existing pipelines get no
+  new warnings and no extra Spark jobs. Pass ``check_srm=True`` to enable
+  the check with equal expected sizes; providing ``srm_expected_ratios``
+  enables it automatically (an explicit ``check_srm=False`` always wins).
+  The standalone ``ambrosia.tools.srm.check_srm`` is unchanged.
+
 Version 0.5.3 (11.06.2026)
 ---------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,18 +1,6 @@
 Release Notes
 =============
 
-Version 0.5.4 (unreleased)
----------------------------
-
-**Changes:**
-
-* The Sample Ratio Mismatch check in ``Tester`` is now opt-in: ``run`` no
-  longer verifies the group sizes by default, so existing pipelines get no
-  new warnings and no extra Spark jobs. Pass ``check_srm=True`` to enable
-  the check with equal expected sizes; providing ``srm_expected_ratios``
-  enables it automatically (an explicit ``check_srm=False`` always wins).
-  The standalone ``ambrosia.tools.srm.check_srm`` is unchanged.
-
 Version 0.5.3 (11.06.2026)
 ---------------------------
 
@@ -20,13 +8,15 @@ Version 0.5.3 (11.06.2026)
 
 * Sample Ratio Mismatch (SRM) check. A broken assignment, filtering or logging
   pipeline often shows up as group sizes that deviate from the planned split -
-  and then any test result on such groups cannot be trusted. The ``Tester`` now
-  verifies the observed group sizes with a chi-square test (strict ``0.0005``
-  level) before evaluating the results and emits a warning when a mismatch is
-  detected. For intentionally unequal splits pass ``srm_expected_ratios``
-  (e.g. ``{"A": 0.9, "B": 0.1}``); disable with ``check_srm=False``. The same
-  diagnostic is available standalone as ``ambrosia.tools.srm.check_srm`` for
-  pandas and Spark dataframes.
+  and then any test result on such groups cannot be trusted. ``Tester.run``
+  can now verify the observed group sizes with a chi-square test (strict
+  ``0.0005`` level) before evaluating the results and warn when a mismatch
+  is detected. The check is opt-in: pass ``check_srm=True`` for equal
+  expected sizes, or provide ``srm_expected_ratios``
+  (e.g. ``{"A": 0.9, "B": 0.1}``) for intentionally unequal splits - the
+  ratios enable the check automatically. The same diagnostic is available
+  standalone as ``ambrosia.tools.srm.check_srm`` for pandas and Spark
+  dataframes.
 
 **Bug Fixes:**
 

--- a/ambrosia/tester/tester.py
+++ b/ambrosia/tester/tester.py
@@ -525,7 +525,7 @@ class Tester(ABToolAbstract):
         correction_method: Union[str, None] = "bonferroni",
         as_table: bool = True,
         metric_funcs: Optional[Dict[str, Callable]] = None,
-        check_srm: bool = True,
+        check_srm: Optional[bool] = None,
         srm_expected_ratios: Optional[Dict[Any, float]] = None,
         **kwargs,
     ) -> types.TesterResult:
@@ -581,14 +581,17 @@ class Tester(ABToolAbstract):
             Each function receives a group ``pd.DataFrame`` and returns
             array-like values. Overrides functions set in constructor
             for matching metric names. Only pandas DataFrames supported.
-        check_srm : bool, default: ``True``
+        check_srm : bool, optional
             Run a Sample Ratio Mismatch check on the group sizes before
             testing and emit a warning if the observed sizes deviate from
             the expected ratios (chi-square test at the ``0.0005`` level).
             A detected mismatch usually means a broken assignment procedure,
-            making the test results unreliable. The check assumes one row
-            per randomization unit (e.g. one user); for Spark data it
-            triggers a count job per group.
+            making the test results unreliable. By default the check runs
+            only when ``srm_expected_ratios`` is provided; pass ``True`` to
+            enable it with equal expected sizes or ``False`` to disable it
+            entirely. The check assumes one row per randomization unit
+            (e.g. one user); for Spark data it triggers a count job per
+            group.
         srm_expected_ratios : Dict[Any, float], optional
             Expected group size ratios for the Sample Ratio Mismatch check,
             mapping group label to its share (normalized internally).
@@ -634,7 +637,8 @@ class Tester(ABToolAbstract):
         effective_metric_funcs = {**self.__metric_funcs, **(metric_funcs or {})}
         chosen_args["metric_funcs"] = effective_metric_funcs
 
-        if check_srm:
+        run_srm_check: bool = check_srm if check_srm is not None else srm_expected_ratios is not None
+        if run_srm_check:
             Tester.__warn_on_srm(chosen_args["experiment_results"], srm_expected_ratios)
 
         hypothesis_num: int = len(list(itertools.combinations(chosen_args["experiment_results"], 2))) * len(
@@ -687,7 +691,7 @@ def test(
     correction_method: Union[str, None] = "bonferroni",
     as_table: bool = True,
     metric_funcs: Optional[Dict[str, Callable]] = None,
-    check_srm: bool = True,
+    check_srm: Optional[bool] = None,
     srm_expected_ratios: Optional[Dict[Any, float]] = None,
     **kwargs,
 ) -> types.TesterResult:
@@ -747,10 +751,12 @@ def test(
         Dictionary mapping metric names to callable functions.
         Each function receives a group ``pd.DataFrame`` and returns
         array-like values. Only pandas DataFrames supported.
-    check_srm : bool, default: ``True``
+    check_srm : bool, optional
         Run a Sample Ratio Mismatch check on the group sizes before
         testing and emit a warning if the observed sizes deviate from
-        the expected ratios.
+        the expected ratios. By default the check runs only when
+        ``srm_expected_ratios`` is provided; pass ``True`` to enable it
+        with equal expected sizes or ``False`` to disable it entirely.
     srm_expected_ratios : Dict[Any, float], optional
         Expected group size ratios for the Sample Ratio Mismatch check.
         Pass it when the split is intentionally unequal.

--- a/docs/source/ambrosia_elements/tester.rst
+++ b/docs/source/ambrosia_elements/tester.rst
@@ -21,13 +21,14 @@ and calculating the experimental uplift value with corresponding confidence inte
 .. admonition:: Sample Ratio Mismatch check
    :class: caution
 
-   Before evaluating the results, ``Tester`` checks that the observed group sizes match the expected
-   ratios (a chi-square test at the strict ``0.0005`` level) and emits a warning when a Sample Ratio
-   Mismatch is detected — such a mismatch usually means a broken assignment procedure, making the test
-   results unreliable. The check assumes one row per randomization unit (e.g. one user): on event- or
-   session-level data aggregate to units first or disable the check. For intentionally unequal splits
-   pass ``srm_expected_ratios`` (e.g. ``{"A": 0.9, "B": 0.1}``); the check can be disabled with
-   ``check_srm=False`` (for Spark data it costs one count job per group).
+   ``Tester`` can verify that the observed group sizes match the expected ratios before evaluating
+   the results (a chi-square test at the strict ``0.0005`` level) and warn when a Sample Ratio
+   Mismatch is detected — such a mismatch usually means a broken assignment procedure, making the
+   test results unreliable. The check is opt-in: pass ``check_srm=True`` to ``run`` for equal
+   expected sizes, or provide ``srm_expected_ratios`` (e.g. ``{"A": 0.9, "B": 0.1}``) for
+   intentionally unequal splits — supplying the ratios enables the check automatically.
+   The check assumes one row per randomization unit (e.g. one user): on event- or session-level
+   data aggregate to units first; for Spark data it costs one count job per group.
    The standalone function ``ambrosia.tools.srm.check_srm`` runs the same diagnostic on any
    pandas or Spark dataframe.
 

--- a/tests/test_srm.py
+++ b/tests/test_srm.py
@@ -138,19 +138,46 @@ def test_dataframe_wrapper_missing_column():
 def test_tester_warns_on_srm():
     tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
     with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
-        tester.run("absolute", method="theory", as_table=False)
+        tester.run("absolute", method="theory", as_table=False, check_srm=True)
 
 
 @pytest.mark.unit
 def test_tester_silent_on_balanced_split():
     tester = Tester(dataframe=make_groups_frame(5000, 4980), column_groups="group", metrics=["metric"])
+    assert not collect_srm_warnings(lambda: tester.run("absolute", method="theory", as_table=False, check_srm=True))
+
+
+@pytest.mark.unit
+def test_tester_srm_off_by_default():
+    """
+    The check is opt-in: a skewed split produces no warning unless enabled.
+    """
+    tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
     assert not collect_srm_warnings(lambda: tester.run("absolute", method="theory", as_table=False))
 
 
 @pytest.mark.unit
-def test_tester_srm_check_can_be_disabled():
+def test_tester_explicit_false_wins_over_ratios():
     tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
-    assert not collect_srm_warnings(lambda: tester.run("absolute", method="theory", as_table=False, check_srm=False))
+    assert not collect_srm_warnings(
+        lambda: tester.run(
+            "absolute",
+            method="theory",
+            as_table=False,
+            check_srm=False,
+            srm_expected_ratios={"A": 0.5, "B": 0.5},
+        )
+    )
+
+
+@pytest.mark.unit
+def test_ratios_alone_enable_check():
+    """
+    Providing srm_expected_ratios opts into the check automatically.
+    """
+    tester = Tester(dataframe=make_groups_frame(5000, 4500), column_groups="group", metrics=["metric"])
+    with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
+        tester.run("absolute", method="theory", as_table=False, srm_expected_ratios={"A": 0.5, "B": 0.5})
 
 
 @pytest.mark.unit
@@ -161,7 +188,7 @@ def test_tester_respects_expected_ratios():
     frame = make_groups_frame(9000, 1020)
     tester = Tester(dataframe=frame, column_groups="group", metrics=["metric"])
     with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
-        tester.run("absolute", method="theory", as_table=False)
+        tester.run("absolute", method="theory", as_table=False, check_srm=True)
     assert not collect_srm_warnings(
         lambda: tester.run(
             "absolute",
@@ -176,7 +203,7 @@ def test_tester_respects_expected_ratios():
 def test_standalone_test_function_passthrough():
     frame = make_groups_frame(5000, 4500)
     with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
-        test("absolute", dataframe=frame, column_groups="group", metrics="metric", as_table=False)
+        test("absolute", dataframe=frame, column_groups="group", metrics="metric", as_table=False, check_srm=True)
     assert not collect_srm_warnings(
         lambda: test(
             "absolute",
@@ -184,7 +211,6 @@ def test_standalone_test_function_passthrough():
             column_groups="group",
             metrics="metric",
             as_table=False,
-            check_srm=False,
         )
     )
 
@@ -212,7 +238,7 @@ def test_tester_experiment_results_dict_mode():
     }
     tester = Tester(experiment_results=experiment_results, metrics=["metric"])
     with pytest.warns(UserWarning, match="Sample Ratio Mismatch detected"):
-        tester.run("absolute", method="theory", as_table=False)
+        tester.run("absolute", method="theory", as_table=False, check_srm=True)
 
 
 @pytest.mark.unit
@@ -231,6 +257,7 @@ def test_tester_experiment_results_arrays_supported():
         metric_funcs={"metric": lambda values: values},
         as_table=False,
         random_seed=7,
+        check_srm=True,
     )
     assert "pvalue" in result[0]
 


### PR DESCRIPTION
Flips the default of the 0.5.3 SRM check in `Tester.run`: **no check unless requested** — existing pipelines get no new warnings and no extra Spark count jobs.

Semantics (tri-state `check_srm`):
- `None` (default): the check runs **only when `srm_expected_ratios` is provided** — supplying expected ratios is treated as opting in, so they are never silently ignored;
- `True`: enable with equal expected sizes;
- explicit `False`: always disabled (wins over provided ratios).

Standalone `ambrosia.tools.srm.check_srm` unchanged. Docs/admonition reworded to opt-in, CHANGELOG entry under 0.5.4 (unreleased). Tests: 27 SRM tests incl. off-by-default, auto-opt-in via ratios and explicit-override cases; full suite 1785 passed / 0 failed.